### PR TITLE
[psm] Update `Find-UnifiedJob`: enable pipline inputs

### DIFF
--- a/docs/en-US/cmdlets/Find-UnifiedJob.md
+++ b/docs/en-US/cmdlets/Find-UnifiedJob.md
@@ -12,9 +12,16 @@ Retrieve Unified Jobs.
 
 ## SYNTAX
 
+### All (Default)
 ```
 Find-UnifiedJob [-OrderBy <String[]>] [-Search <String[]>] [-Count <UInt16>] [-Page <UInt32>] [-All]
  [<CommonParameters>]
+```
+
+### AssociatedWith
+```
+Find-UnifiedJob -Type <ResourceType> -Id <UInt64> [-OrderBy <String[]>] [-Search <String[]>] [-Count <UInt16>]
+ [-Page <UInt32>] [-All] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -22,6 +29,17 @@ Retrieve Jobs which are Job, ProjectUpdate, InventoryUpdate, SystemJob, AdHocCom
 
 Implementation of following API:  
 - `/api/v2/unified_jobs/`  
+- `/api/v2/hosts/{id}/ad_hoc_commands/`  
+- `/api/v2/groups/{id}/ad_hoc_commands/`  
+- `/api/v2/schedules/{id}/jobs/`  
+- `/api/v2/instances/{id}/jobs/`  
+- `/api/v2/instance_groups/{id}/jobs/`  
+- `/api/v2/job_templates/{id}/jobs/`  
+- `/api/v2/workflow_job_templates/{id}/workflow_jobs/`  
+- `/api/v2/projects/{id}/project_updates/`  
+- `/api/v2/inventory_sources/{id}/inventory_updates/`  
+- `/api/v2/system_job_templates/{id}/jobs/`  
+- `/api/v2/inventories/{id}/ad_hoc_commands/`
 
 ## EXAMPLES
 
@@ -59,6 +77,22 @@ Required: False
 Position: Named
 Default value: 20
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Datebase ID of the target resource.
+Use in conjection with the `-Type` parameter.
+
+```yaml
+Type: UInt64
+Parameter Sets: AssociatedWith
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -115,12 +149,49 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Type
+Resource type name of the target.
+Use in conjection with the `-Id` parameter.
+
+```yaml
+Type: ResourceType
+Parameter Sets: AssociatedWith
+Aliases:
+Accepted values: JobTemplate, WorkflowJobTemplate, Project, InventorySource, SystemJobTemplate, Inventory, Host, Group, Schedule, Instance, InstanceGroup
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### None
+### AWX.Resources.ResourceType
+Input by `Type` property in the pipeline object.
+
+Acceptable values:  
+- `Group`  
+- `Host`  
+- `Instance`  
+- `InstanceGroup`  
+- `Inventory`  
+- `InventorySource`  
+- `JobTemplate`  
+- `Project`  
+- `Schedule`  
+- `SystemJobTemplate`  
+- `WorkflowJobTemplate`
+
+### System.UInt64
+Input by `Id` property in the pipeline object.
+
+Database ID for the ResourceType
+
 ## OUTPUTS
 
 ### AWX.Resources.IUnifiedJob
@@ -130,7 +201,7 @@ Unified Job objects which are following instances implemented `IUnifiedJob`:
 - `InventoryUpdate` : Inventory Update job  
 - `SystemJob`       : SystemJobTemplate's job  
 - `AdHocCommand`    : AdHocCommand job  
-- `WorkflowJob`     : WorkflowJobTemplate's job  
+- `WorkflowJob`     : WorkflowJobTemplate's job
 
 ## NOTES
 


### PR DESCRIPTION
Accept pipline inputs:
- `JobTemplate` -> Retrieve the JobTemplate's jobs
- `Project` -> Retrieve the Project's jobs (`ProjectUpdate`)
- `InventorySource` -> Retrieve the InventorySource's jobs (`InventoryUpdate`)
- `WorkflowJobTemplate` -> Retrieve the WorkflowJobTemplate7s jobs (`WorkflowJob`)
- `Inventory`, `Host`, `Group` -> Retrieve the resource's AdHocCommand jobs (`AdHocCommand`)
- `Schedule` -> Retreive jobs launched by the Schedule (`IUnifiedJob`)
- `Instance` -> Retrieve jobs launched on the Instance  (`IUnifiedJob`)
- `InstanceGroup` -> Retrieve jobs launched on the Instance  (`IUnifiedJob`)