### PR TITLE
Improve JobTempalte and WorkflowJobTemplate launcher

### DIFF
--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -16,14 +16,15 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
  [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>]
- [-SkipTags <String[]>] [-ExtraVars <String>] [<CommonParameters>]
+ [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
  [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>]
- [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
+ [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
  [<CommonParameters>]
 ```
 
@@ -71,6 +72,24 @@ localhost                  : ok=2    changed=0    unreachable=0    failed=0    s
 Launch JobTemplate ID 7, and wait unti for the job is finished.
 
 ## PARAMETERS
+
+### -DiffMode
+Specify diff mode.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ExtraVars
 Specify extra variables.

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -15,16 +15,16 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 ### Id
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
- [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>]
- [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
+ [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>]
+ [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
  [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
- [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>]
- [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
+ [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>]
+ [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
  [<CommonParameters>]
 ```
 
@@ -72,6 +72,24 @@ localhost                  : ok=2    changed=0    unreachable=0    failed=0    s
 Launch JobTemplate ID 7, and wait unti for the job is finished.
 
 ## PARAMETERS
+
+### -Credentials
+Specify credential IDs.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -DiffMode
 Specify diff mode.

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -15,15 +15,15 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 ### Id
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
- [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>]
- [<CommonParameters>]
+ [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>]
+ [-SkipTags <String[]>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
  [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>]
- [<CommonParameters>]
+ [-Tags <String[]>] [-SkipTags <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -208,6 +208,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -SkipTags
+Specify skip tags. (commas `,` separated)
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -SuppressJobLog
 Suppress display job log.
 
@@ -228,6 +246,24 @@ Suppress display job log.
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tags
+Specify tags. (commas `,` separated)
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -14,14 +14,15 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 
 ### Id
 ```
-Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-JobType <JobType>]
- [-Limit <String>] [<CommonParameters>]
+Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
+ [-JobType <JobType>] [-Limit <String>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
- [-JobType <JobType>] [-Limit <String>] [<CommonParameters>]
+ [-Inventory <UInt64>] [-JobType <JobType>] [-Limit <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -96,6 +97,24 @@ Aliases:
 Required: False
 Position: Named
 Default value: 5
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Inventory
+Inventory ID
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -17,7 +17,7 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
  [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>]
  [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
- [<CommonParameters>]
+ [-Verbosity <JobVerbosity>] [<CommonParameters>]
 ```
 
 ### JobTemplate
@@ -25,7 +25,7 @@ Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
  [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>]
  [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
- [<CommonParameters>]
+ [-Verbosity <JobVerbosity>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -322,6 +322,25 @@ Specify tags. (commas `,` separated)
 Type: String[]
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbosity
+Specify job verbosity.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: JobVerbosity
+Parameter Sets: (All)
+Aliases:
+Accepted values: Normal, Verbose, MoreVerbose, Debug, ConnectionDebug, WinRMDebug
 
 Required: False
 Position: Named

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -15,14 +15,14 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 ### Id
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
- [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>]
+ [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>]
  [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
- [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>]
+ [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>]
  [<CommonParameters>]
 ```
 
@@ -146,6 +146,24 @@ Type: JobType
 Parameter Sets: (All)
 Aliases:
 Accepted values: Run, Check
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Labels
+Label IDs
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -18,7 +18,7 @@ Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [
  [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>]
  [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
  [-Verbosity <JobVerbosity>] [-Forks <Int32>] [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>]
- [<CommonParameters>]
+ [-Timeout <Int32>] [<CommonParameters>]
 ```
 
 ### JobTemplate
@@ -27,7 +27,7 @@ Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <
  [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>]
  [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
  [-Verbosity <JobVerbosity>] [-Forks <Int32>] [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>]
- [<CommonParameters>]
+ [-Timeout <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -376,6 +376,24 @@ Specify tags. (commas `,` separated)
 
 ```yaml
 Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Timeout
+Specify timeout value (seconds).
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -15,13 +15,14 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 ### Id
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
- [-JobType <JobType>] [-Limit <String>] [<CommonParameters>]
+ [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
- [-Inventory <UInt64>] [-JobType <JobType>] [-Limit <String>]
+ [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>]
  [<CommonParameters>]
 ```
 
@@ -158,6 +159,24 @@ Further limit selected hosts to an additional pattern.
 
 > [!NOTE]  
 > This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScmBranch
+Specify branch to use in job run. Project default is used if omitted.
+
+> [!NOTE]  
+> This parameter will be ignored if the Project's `AllowOverride` flag is on and  "Ask" flag is off, although the request will be sent.
 
 ```yaml
 Type: String

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -118,6 +118,9 @@ Accept wildcard characters: False
 ### -Limit
 Further limit selected hosts to an additional pattern.
 
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
 ```yaml
 Type: String
 Parameter Sets: (All)

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -17,7 +17,8 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
  [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>]
  [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
- [-Verbosity <JobVerbosity>] [-Forks <Int32>] [<CommonParameters>]
+ [-Verbosity <JobVerbosity>] [-Forks <Int32>] [-ExecutionEnvironment <UInt64>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
@@ -25,7 +26,8 @@ Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
  [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>]
  [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
- [-Verbosity <JobVerbosity>] [-Forks <Int32>] [<CommonParameters>]
+ [-Verbosity <JobVerbosity>] [-Forks <Int32>] [-ExecutionEnvironment <UInt64>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -99,6 +101,24 @@ Specify diff mode.
 
 ```yaml
 Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionEnvironment
+Specify ExecutionEnvironment ID.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -17,7 +17,7 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
  [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>]
  [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
- [-Verbosity <JobVerbosity>] [-Forks <Int32>] [-ExecutionEnvironment <UInt64>]
+ [-Verbosity <JobVerbosity>] [-Forks <Int32>] [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>]
  [<CommonParameters>]
 ```
 
@@ -26,7 +26,7 @@ Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
  [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>]
  [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
- [-Verbosity <JobVerbosity>] [-Forks <Int32>] [-ExecutionEnvironment <UInt64>]
+ [-Verbosity <JobVerbosity>] [-Forks <Int32>] [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>]
  [<CommonParameters>]
 ```
 
@@ -204,6 +204,24 @@ Inventory ID
 
 ```yaml
 Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -JobSliceCount
+Specify the number of job slice count.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -14,14 +14,14 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 
 ### Id
 ```
-Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Limit <String>]
- [<CommonParameters>]
+Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-JobType <JobType>]
+ [-Limit <String>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
-Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate> [-Limit <String>]
- [<CommonParameters>]
+Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
+ [-JobType <JobType>] [-Limit <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -112,6 +112,25 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -JobType
+Specify JobType ("Run" or "Check")
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: JobType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Run, Check
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -17,7 +17,7 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
  [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>]
  [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
- [-Verbosity <JobVerbosity>] [<CommonParameters>]
+ [-Verbosity <JobVerbosity>] [-Forks <Int32>] [<CommonParameters>]
 ```
 
 ### JobTemplate
@@ -25,7 +25,7 @@ Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
  [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Credentials <UInt64[]>] [-Limit <String>]
  [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>] [-DiffMode <Boolean>]
- [-Verbosity <JobVerbosity>] [<CommonParameters>]
+ [-Verbosity <JobVerbosity>] [-Forks <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -117,6 +117,24 @@ Specify extra variables.
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Forks
+Specify the number of forks.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Invoke-JobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-JobTemplate.md
@@ -16,14 +16,15 @@ Invoke (launch) a JobTemplate and wait unti the job is finished.
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Inventory <UInt64>]
  [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>]
- [-SkipTags <String[]>] [<CommonParameters>]
+ [-SkipTags <String[]>] [-ExtraVars <String>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-JobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-JobTemplate] <JobTemplate>
  [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>] [-Limit <String>] [-Labels <UInt64[]>]
- [-Tags <String[]>] [-SkipTags <String[]>] [<CommonParameters>]
+ [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -70,6 +71,24 @@ localhost                  : ok=2    changed=0    unreachable=0    failed=0    s
 Launch JobTemplate ID 7, and wait unti for the job is finished.
 
 ## PARAMETERS
+
+### -ExtraVars
+Specify extra variables.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
 JobTemplate ID to be launched.

--- a/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
@@ -15,14 +15,15 @@ Invoke (update) a WorkflowJobTemplate and wait until the job is finished.
 ### Id
 ```
 Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Limit <String>]
- [-Inventory <UInt64>] [-ScmBranch <String>] [<CommonParameters>]
+ [-Inventory <UInt64>] [-ScmBranch <String>] [-Labels <UInt64[]>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog]
  [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>] [-ScmBranch <String>]
- [<CommonParameters>]
+ [-Labels <UInt64[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -96,6 +97,24 @@ Inventory ID
 
 ```yaml
 Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Labels
+Label IDs
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
@@ -15,7 +15,7 @@ Invoke (update) a WorkflowJobTemplate and wait until the job is finished.
 ### Id
 ```
 Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Limit <String>]
- [-Inventory <UInt64>] [-ScmBranch <String>] [-Labels <UInt64[]>]
+ [-Inventory <UInt64>] [-ScmBranch <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
  [<CommonParameters>]
 ```
 
@@ -23,7 +23,8 @@ Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <U
 ```
 Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog]
  [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>] [-ScmBranch <String>]
- [-Labels <UInt64[]>] [<CommonParameters>]
+ [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -161,6 +162,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -SkipTags
+Specify skip tags. (commas `,` separated)
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -SuppressJobLog
 Suppress display job log.
 
@@ -186,6 +205,24 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tags
+Specify tags. (commas `,` separated)
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
@@ -91,6 +91,9 @@ Accept wildcard characters: False
 ### -Inventory
 Inventory ID
 
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
 ```yaml
 Type: UInt64
 Parameter Sets: (All)
@@ -105,6 +108,9 @@ Accept wildcard characters: False
 
 ### -Limit
 Further limit selected hosts to an additional pattern.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
 
 ```yaml
 Type: String

--- a/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
@@ -15,13 +15,13 @@ Invoke (update) a WorkflowJobTemplate and wait until the job is finished.
 ### Id
 ```
 Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Limit <String>]
- [-Inventory <UInt64>] [<CommonParameters>]
+ [-Inventory <UInt64>] [-ScmBranch <String>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog]
- [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>]
+ [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>] [-ScmBranch <String>]
  [<CommonParameters>]
 ```
 
@@ -111,6 +111,24 @@ Further limit selected hosts to an additional pattern.
 
 > [!NOTE]  
 > This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScmBranch
+Specify branch to use in job run. Project default is used if omitted.
+
+> [!NOTE]  
+> This parameter will be ignored if the Project's `AllowOverride` flag is on and  "Ask" flag is off, although the request will be sent.
 
 ```yaml
 Type: String

--- a/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Invoke-WorkflowJobTemplate.md
@@ -16,14 +16,14 @@ Invoke (update) a WorkflowJobTemplate and wait until the job is finished.
 ```
 Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog] [-Id] <UInt64> [-Limit <String>]
  [-Inventory <UInt64>] [-ScmBranch <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
- [<CommonParameters>]
+ [-ExtraVars <String>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Invoke-WorkflowJobTemplate [-IntervalSeconds <Int32>] [-SuppressJobLog]
  [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>] [-ScmBranch <String>]
- [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
  [<CommonParameters>]
 ```
 
@@ -58,6 +58,24 @@ PS C:\> Invoke-WorkflowJobTemplate -Id 13
 Launch WorkflowJobTemplate ID 13, and wait unti for the job is finished.
 
 ## PARAMETERS
+
+### -ExtraVars
+Specify extra variables.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
 WorkflowJobTemplate ID to be launched.

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -17,7 +17,7 @@ Invoke (launch) a JobTemplate.
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
  [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>] [-Forks <Int32>]
- [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>]
+ [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>] [-Timeout <Int32>]
  [<CommonParameters>]
 ```
 
@@ -26,7 +26,7 @@ Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-Sc
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
  [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>] [-Forks <Int32>]
- [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>]
+ [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>] [-Timeout <Int32>]
  [<CommonParameters>]
 ```
 
@@ -346,6 +346,24 @@ Specify tags. (commas `,` separated)
 
 ```yaml
 Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Timeout
+Specify timeout value (seconds).
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -16,7 +16,7 @@ Invoke (launch) a JobTemplate.
 ```
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
- [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>]
+ [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>] [-Forks <Int32>]
  [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-Sc
 ```
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
- [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>]
+ [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>] [-Forks <Int32>]
  [<CommonParameters>]
 ```
 
@@ -133,6 +133,24 @@ Specify extra variables.
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Forks
+Specify the number of forks.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -16,14 +16,16 @@ Invoke (launch) a JobTemplate.
 ```
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
- [-ExtraVars <String>] [-DiffMode <Boolean>] [<CommonParameters>]
+ [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
- [-ExtraVars <String>] [-DiffMode <Boolean>] [<CommonParameters>]
+ [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -290,6 +292,25 @@ Specify tags. (commas `,` separated)
 Type: String[]
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verbosity
+Specify job verbosity.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: JobVerbosity
+Parameter Sets: (All)
+Aliases:
+Accepted values: Normal, Verbose, MoreVerbose, Debug, ConnectionDebug, WinRMDebug
 
 Required: False
 Position: Named

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -117,6 +117,9 @@ Accept wildcard characters: False
 ### -Limit
 Further limit selected hosts to an additional pattern.
 
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
 ```yaml
 Type: String
 Parameter Sets: (All)

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -15,13 +15,13 @@ Invoke (launch) a JobTemplate.
 ### Id
 ```
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
- [-Limit <String>] [<CommonParameters>]
+ [-Limit <String>] [-Labels <UInt64[]>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
- [-Limit <String>] [<CommonParameters>]
+ [-Limit <String>] [-Labels <UInt64[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -144,6 +144,24 @@ Type: JobType
 Parameter Sets: (All)
 Aliases:
 Accepted values: Run, Check
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Labels
+Label IDs
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -14,12 +14,13 @@ Invoke (launch) a JobTemplate.
 
 ### Id
 ```
-Start-JobTemplate [-Id] <UInt64> [-Limit <String>] [<CommonParameters>]
+Start-JobTemplate [-Id] <UInt64> [-JobType <JobType>] [-Limit <String>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
-Start-JobTemplate [-JobTemplate] <JobTemplate> [-Limit <String>]
+Start-JobTemplate [-JobTemplate] <JobTemplate> [-JobType <JobType>] [-Limit <String>]
  [<CommonParameters>]
 ```
 
@@ -111,6 +112,25 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -JobType
+Specify JobType ("Run" or "Check")
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: JobType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Run, Check
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -15,15 +15,15 @@ Invoke (launch) a JobTemplate.
 ### Id
 ```
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
- [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
- [-DiffMode <Boolean>] [<CommonParameters>]
+ [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [-ExtraVars <String>] [-DiffMode <Boolean>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
- [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
- [-DiffMode <Boolean>] [<CommonParameters>]
+ [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [-ExtraVars <String>] [-DiffMode <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -86,6 +86,24 @@ Launch JobTemplate ID 7, and wait unti for the job is finished.
 This is almost same as `Invoke-JobTemplate` command.
 
 ## PARAMETERS
+
+### -Credentials
+Specify credential IDs.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -DiffMode
 Specify diff mode.

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -14,13 +14,13 @@ Invoke (launch) a JobTemplate.
 
 ### Id
 ```
-Start-JobTemplate [-Id] <UInt64> [-JobType <JobType>] [-Limit <String>]
+Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-Limit <String>]
  [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
-Start-JobTemplate [-JobTemplate] <JobTemplate> [-JobType <JobType>] [-Limit <String>]
+Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-Limit <String>]
  [<CommonParameters>]
 ```
 
@@ -97,6 +97,24 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Inventory
+Inventory ID
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -16,14 +16,14 @@ Invoke (launch) a JobTemplate.
 ```
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
- [<CommonParameters>]
+ [-DiffMode <Boolean>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
- [<CommonParameters>]
+ [-DiffMode <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -86,6 +86,24 @@ Launch JobTemplate ID 7, and wait unti for the job is finished.
 This is almost same as `Invoke-JobTemplate` command.
 
 ## PARAMETERS
+
+### -DiffMode
+Specify diff mode.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ExtraVars
 Specify extra variables.

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -17,7 +17,7 @@ Invoke (launch) a JobTemplate.
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
  [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>] [-Forks <Int32>]
- [<CommonParameters>]
+ [-ExecutionEnvironment <UInt64>] [<CommonParameters>]
 ```
 
 ### JobTemplate
@@ -25,7 +25,7 @@ Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-Sc
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
  [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>] [-Forks <Int32>]
- [<CommonParameters>]
+ [-ExecutionEnvironment <UInt64>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -115,6 +115,24 @@ Specify diff mode.
 
 ```yaml
 Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionEnvironment
+Specify ExecutionEnvironment ID.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -15,14 +15,14 @@ Invoke (launch) a JobTemplate.
 ### Id
 ```
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
- [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
  [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
- [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
  [<CommonParameters>]
 ```
 
@@ -86,6 +86,24 @@ Launch JobTemplate ID 7, and wait unti for the job is finished.
 This is almost same as `Invoke-JobTemplate` command.
 
 ## PARAMETERS
+
+### -ExtraVars
+Specify extra variables.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
 JobTemplate ID to be launched.

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -17,7 +17,8 @@ Invoke (launch) a JobTemplate.
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
  [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>] [-Forks <Int32>]
- [-ExecutionEnvironment <UInt64>] [<CommonParameters>]
+ [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
@@ -25,7 +26,8 @@ Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-Sc
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
  [-Credentials <UInt64[]>] [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
  [-ExtraVars <String>] [-DiffMode <Boolean>] [-Verbosity <JobVerbosity>] [-Forks <Int32>]
- [-ExecutionEnvironment <UInt64>] [<CommonParameters>]
+ [-ExecutionEnvironment <UInt64>] [-JobSliceCount <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -202,6 +204,24 @@ Inventory ID
 
 ```yaml
 Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -JobSliceCount
+Specify the number of job slice count.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -15,13 +15,15 @@ Invoke (launch) a JobTemplate.
 ### Id
 ```
 Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
- [-Limit <String>] [-Labels <UInt64[]>] [<CommonParameters>]
+ [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
- [-Limit <String>] [-Labels <UInt64[]>] [<CommonParameters>]
+ [-Limit <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -196,6 +198,42 @@ Specify branch to use in job run. Project default is used if omitted.
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipTags
+Specify skip tags. (commas `,` separated)
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tags
+Specify tags. (commas `,` separated)
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Start-JobTemplate.md
+++ b/docs/en-US/cmdlets/Start-JobTemplate.md
@@ -14,14 +14,14 @@ Invoke (launch) a JobTemplate.
 
 ### Id
 ```
-Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-Limit <String>]
- [<CommonParameters>]
+Start-JobTemplate [-Id] <UInt64> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
+ [-Limit <String>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
-Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-Limit <String>]
- [<CommonParameters>]
+Start-JobTemplate [-JobTemplate] <JobTemplate> [-Inventory <UInt64>] [-JobType <JobType>] [-ScmBranch <String>]
+ [-Limit <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -157,6 +157,24 @@ Further limit selected hosts to an additional pattern.
 
 > [!NOTE]  
 > This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScmBranch
+Specify branch to use in job run. Project default is used if omitted.
+
+> [!NOTE]  
+> This parameter will be ignored if the Project's `AllowOverride` flag is on and  "Ask" flag is off, although the request will be sent.
 
 ```yaml
 Type: String

--- a/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
@@ -15,13 +15,15 @@ Invoke (update) a WorkflowJobTemplate.
 ### Id
 ```
 Start-WorkflowJobTemplate [-Id] <UInt64> [-Limit <String>] [-Inventory <UInt64>] [-ScmBranch <String>]
- [-Labels <UInt64[]>] [<CommonParameters>]
+ [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-WorkflowJobTemplate [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>]
- [-ScmBranch <String>] [-Labels <UInt64[]>] [<CommonParameters>]
+ [-ScmBranch <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -127,6 +129,42 @@ Specify branch to use in job run. Project default is used if omitted.
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipTags
+Specify skip tags. (commas `,` separated)
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tags
+Specify tags. (commas `,` separated)
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
@@ -15,14 +15,14 @@ Invoke (update) a WorkflowJobTemplate.
 ### Id
 ```
 Start-WorkflowJobTemplate [-Id] <UInt64> [-Limit <String>] [-Inventory <UInt64>] [-ScmBranch <String>]
- [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
  [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-WorkflowJobTemplate [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>]
- [-ScmBranch <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>]
+ [-ScmBranch <String>] [-Labels <UInt64[]>] [-Tags <String[]>] [-SkipTags <String[]>] [-ExtraVars <String>]
  [<CommonParameters>]
 ```
 
@@ -51,6 +51,24 @@ PS C:\> Start-WorkflowJobTemplate -Id 13
 Launch WorkflowJobTemplate ID 13.
 
 ## PARAMETERS
+
+### -ExtraVars
+Specify extra variables.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Id
 WorkflowJobTemplate ID to be launched.

--- a/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
@@ -68,6 +68,9 @@ Accept wildcard characters: False
 ### -Inventory
 Inventory ID
 
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
 ```yaml
 Type: UInt64
 Parameter Sets: (All)
@@ -82,6 +85,9 @@ Accept wildcard characters: False
 
 ### -Limit
 Further limit selected hosts to an additional pattern.
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
 
 ```yaml
 Type: String

--- a/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
@@ -14,14 +14,14 @@ Invoke (update) a WorkflowJobTemplate.
 
 ### Id
 ```
-Start-WorkflowJobTemplate [-Id] <UInt64> [-Limit <String>] [-Inventory <UInt64>]
+Start-WorkflowJobTemplate [-Id] <UInt64> [-Limit <String>] [-Inventory <UInt64>] [-ScmBranch <String>]
  [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-WorkflowJobTemplate [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>]
- [<CommonParameters>]
+ [-ScmBranch <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -88,6 +88,24 @@ Further limit selected hosts to an additional pattern.
 
 > [!NOTE]  
 > This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScmBranch
+Specify branch to use in job run. Project default is used if omitted.
+
+> [!NOTE]  
+> This parameter will be ignored if the Project's `AllowOverride` flag is on and  "Ask" flag is off, although the request will be sent.
 
 ```yaml
 Type: String

--- a/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Start-WorkflowJobTemplate.md
@@ -15,13 +15,13 @@ Invoke (update) a WorkflowJobTemplate.
 ### Id
 ```
 Start-WorkflowJobTemplate [-Id] <UInt64> [-Limit <String>] [-Inventory <UInt64>] [-ScmBranch <String>]
- [<CommonParameters>]
+ [-Labels <UInt64[]>] [<CommonParameters>]
 ```
 
 ### JobTemplate
 ```
 Start-WorkflowJobTemplate [-WorkflowJobTemplate] <WorkflowJobTemplate> [-Limit <String>] [-Inventory <UInt64>]
- [-ScmBranch <String>] [<CommonParameters>]
+ [-ScmBranch <String>] [-Labels <UInt64[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -73,6 +73,24 @@ Inventory ID
 
 ```yaml
 Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Labels
+Label IDs
+
+> [!NOTE]  
+> This parameter will be ignored if "Ask" flag is off, although the request will be sent.
+
+```yaml
+Type: UInt64[]
 Parameter Sets: (All)
 Aliases:
 

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -106,6 +106,9 @@ namespace AWX.Cmdlets
         [Parameter()]
         public bool? DiffMode { get; set; }
 
+        [Parameter()]
+        public JobVerbosity? Verbosity { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -148,6 +151,10 @@ namespace AWX.Cmdlets
             if (DiffMode != null)
             {
                 dict.Add("diff_mode", DiffMode);
+            }
+            if (Verbosity != null)
+            {
+                dict.Add("verbosity", (int)Verbosity);
             }
             return dict;
         }
@@ -233,8 +240,12 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Job Type", jobTypeVal),
                                 foregroundColor: requirements.AskJobTypeOnLaunch ? (JobType == null ? implicitColor : explicitColor) : fixedColor);
             }
-            WriteHost(string.Format(fmt, "Verbosity", $"{def.Verbosity:d} ({def.Verbosity})"),
-                            foregroundColor: requirements.AskVerbosityOnLaunch ? implicitColor : fixedColor);
+            {
+                var verbosityVal = $"{def.Verbosity:d} ({def.Verbosity})"
+                                   + (requirements.AskVerbosityOnLaunch && Verbosity != null ? $" => {Verbosity:d} ({Verbosity})" : "");
+                WriteHost(string.Format(fmt, "Verbosity", verbosityVal),
+                                foregroundColor: requirements.AskVerbosityOnLaunch ? (Verbosity == null ? implicitColor : explicitColor) : fixedColor);
+            }
             if (def.Credentials != null || Credentials != null)
             {
                 var credentialsVal = string.Join(", ", def.Credentials?.Select(c => $"[{c.Id}] {c.Name}") ?? [])

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -2,6 +2,7 @@ using AWX.Resources;
 using System.Collections;
 using System.Management.Automation;
 using System.Text;
+using System.Text.Json;
 
 namespace AWX.Cmdlets
 {
@@ -213,7 +214,7 @@ namespace AWX.Cmdlets
             {
                 foreach (var (key, val) in launchResult.IgnoredFields)
                 {
-                    WriteWarning($"Ignored field: {key} ({val})");
+                    WriteWarning($"Ignored field: {key} ({JsonSerializer.Serialize(val, Json.DeserializeOptions)})");
                 }
             }
             return launchResult;

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -90,39 +90,40 @@ namespace AWX.Cmdlets
         {
             var jt = requirements.JobTemplateData;
             var def = requirements.Defaults;
+            var (fixedColor, implicitColor, explicitColor) = ((ConsoleColor?)null, ConsoleColor.Magenta, ConsoleColor.Green);
             WriteHost($"[{jt.Id}] {jt.Name} - {jt.Description}\n");
             var fmt = "{0,22} : {1}\n";
             if (def.Inventory.Id != null)
             {
                 WriteHost(string.Format(fmt, "Inventory", $"[{def.Inventory.Id}] {def.Inventory.Name}"),
-                            foregroundColor: requirements.AskInventoryOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskInventoryOnLaunch ? implicitColor: fixedColor);
             }
             if (!string.IsNullOrEmpty(def.Limit) || Limit != null)
             {
                 var limitVal = def.Limit + (Limit != null ? $" => {Limit}" : "");
 
                 WriteHost(string.Format(fmt, "Limit", $"{limitVal}"),
-                            foregroundColor: requirements.AskLimitOnLaunch ? Limit == null ? ConsoleColor.Magenta : ConsoleColor.Green : null);
+                            foregroundColor: requirements.AskLimitOnLaunch ? (Limit == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.ScmBranch))
             {
                 WriteHost(string.Format(fmt, "Scm Branch", def.ScmBranch),
-                            foregroundColor: requirements.AskScmBranchOnLaunch? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskScmBranchOnLaunch? implicitColor : fixedColor);
             }
             if (def.Labels != null && def.Labels.Length > 0)
             {
                 WriteHost(string.Format(fmt, "Labels", string.Join(", ", def.Labels.Select(l => $"[{l.Id}] {l.Name}"))),
-                            foregroundColor: requirements.AskLabelsOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskLabelsOnLaunch ? implicitColor : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.JobTags))
             {
                 WriteHost(string.Format(fmt, "Job tags", def.JobTags),
-                            foregroundColor: requirements.AskTagsOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskTagsOnLaunch ? implicitColor : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.SkipTags))
             {
                 WriteHost(string.Format(fmt, "Skip tags", def.SkipTags),
-                            foregroundColor: requirements.AskSkipTagsOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskSkipTagsOnLaunch ? implicitColor : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.ExtraVars))
             {
@@ -134,30 +135,30 @@ namespace AWX.Cmdlets
                     sb.AppendLine("".PadLeft(25) + line);
                 }
                 WriteHost(sb.ToString(),
-                            foregroundColor: requirements.AskVariablesOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskVariablesOnLaunch ? implicitColor : fixedColor);
             }
             WriteHost(string.Format(fmt, "Diff Mode", def.DiffMode),
-                            foregroundColor: requirements.AskDiffModeOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskDiffModeOnLaunch ? implicitColor : fixedColor);
             WriteHost(string.Format(fmt, "Job Type", def.JobType),
-                            foregroundColor: requirements.AskJobTypeOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskJobTypeOnLaunch ? implicitColor : fixedColor);
             WriteHost(string.Format(fmt, "Verbosity", $"{def.Verbosity:d} ({def.Verbosity})"),
-                            foregroundColor: requirements.AskVerbosityOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskVerbosityOnLaunch ? implicitColor : fixedColor);
             if (def.Credentials != null)
             {
                 WriteHost(string.Format(fmt, "Credentials", string.Join(", ", def.Credentials.Select(c => $"[{c.Id}] {c.Name}"))),
-                            foregroundColor: requirements.AskCredentialOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskCredentialOnLaunch ? implicitColor : fixedColor);
             }
             if (def.ExecutionEnvironment.Id != null)
             {
                 WriteHost(string.Format(fmt, "ExecutionEnvironment", $"[{def.ExecutionEnvironment.Id}] {def.ExecutionEnvironment.Name}"),
-                            foregroundColor: requirements.AskExecutionEnvironmentOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskExecutionEnvironmentOnLaunch ? implicitColor : fixedColor);
             }
             WriteHost(string.Format(fmt, "Forks", def.Forks),
-                            foregroundColor: requirements.AskForksOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskForksOnLaunch ? implicitColor : fixedColor);
             WriteHost(string.Format(fmt, "Job Slice Count", def.JobSliceCount),
-                            foregroundColor: requirements.AskJobSliceCountOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskJobSliceCountOnLaunch ? implicitColor : fixedColor);
             WriteHost(string.Format(fmt, "Timeout", def.Timeout),
-                            foregroundColor: requirements.AskTimeoutOnLaunch ? ConsoleColor.Magenta : ConsoleColor.Green);
+                            foregroundColor: requirements.AskTimeoutOnLaunch ? implicitColor : fixedColor);
         }
         protected JobTemplateJob.LaunchResult? Launch(ulong id)
         {

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -75,11 +75,19 @@ namespace AWX.Cmdlets
         public JobTemplate? JobTemplate { get; set; }
 
         [Parameter()]
+        [ValidateSet(nameof(Resources.JobType.Run), nameof(Resources.JobType.Check))]
+        public JobType? JobType { get; set; }
+
+        [Parameter()]
         public string? Limit { get; set; }
 
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
+            if (JobType != null)
+            {
+                dict.Add("job_type", $"{JobType}".ToLowerInvariant());
+            }
             if (Limit != null)
             {
                 dict.Add("limit", Limit);
@@ -139,8 +147,12 @@ namespace AWX.Cmdlets
             }
             WriteHost(string.Format(fmt, "Diff Mode", def.DiffMode),
                             foregroundColor: requirements.AskDiffModeOnLaunch ? implicitColor : fixedColor);
-            WriteHost(string.Format(fmt, "Job Type", def.JobType),
-                            foregroundColor: requirements.AskJobTypeOnLaunch ? implicitColor : fixedColor);
+            {
+                var jobTypeVal = def.JobType
+                                 + (requirements.AskJobTypeOnLaunch && JobType != null ? $" => {JobType}" : "");
+                WriteHost(string.Format(fmt, "Job Type", jobTypeVal),
+                                foregroundColor: requirements.AskJobTypeOnLaunch ? (JobType == null ? implicitColor : explicitColor) : fixedColor);
+            }
             WriteHost(string.Format(fmt, "Verbosity", $"{def.Verbosity:d} ({def.Verbosity})"),
                             foregroundColor: requirements.AskVerbosityOnLaunch ? implicitColor : fixedColor);
             if (def.Credentials != null)

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -86,6 +86,9 @@ namespace AWX.Cmdlets
         public string? ScmBranch { get; set; }
 
         [Parameter()]
+        public ulong[]? Credentials { get; set; }
+
+        [Parameter()]
         public string? Limit { get; set; }
 
         [Parameter()] // XXX: Should be string[] and created if not exists ?
@@ -117,6 +120,10 @@ namespace AWX.Cmdlets
             if (ScmBranch != null)
             {
                 dict.Add("scm_branch", ScmBranch);
+            }
+            if (Credentials != null)
+            {
+                dict.Add("credentials", Credentials);
             }
             if (Limit != null)
             {
@@ -228,10 +235,12 @@ namespace AWX.Cmdlets
             }
             WriteHost(string.Format(fmt, "Verbosity", $"{def.Verbosity:d} ({def.Verbosity})"),
                             foregroundColor: requirements.AskVerbosityOnLaunch ? implicitColor : fixedColor);
-            if (def.Credentials != null)
+            if (def.Credentials != null || Credentials != null)
             {
-                WriteHost(string.Format(fmt, "Credentials", string.Join(", ", def.Credentials.Select(c => $"[{c.Id}] {c.Name}"))),
-                            foregroundColor: requirements.AskCredentialOnLaunch ? implicitColor : fixedColor);
+                var credentialsVal = string.Join(", ", def.Credentials?.Select(c => $"[{c.Id}] {c.Name}") ?? [])
+                        + (requirements.AskCredentialOnLaunch && Credentials != null ? $" => {string.Join(',', Credentials.Select(id => $"[{id}]"))}" : "");
+                WriteHost(string.Format(fmt, "Credentials", credentialsVal),
+                            foregroundColor: requirements.AskCredentialOnLaunch ? (Credentials == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (def.ExecutionEnvironment.Id != null)
             {

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -75,6 +75,9 @@ namespace AWX.Cmdlets
         public JobTemplate? JobTemplate { get; set; }
 
         [Parameter()]
+        public ulong? Inventory { get; set; }
+
+        [Parameter()]
         [ValidateSet(nameof(Resources.JobType.Run), nameof(Resources.JobType.Check))]
         public JobType? JobType { get; set; }
 
@@ -84,6 +87,10 @@ namespace AWX.Cmdlets
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
+            if (Inventory != null)
+            {
+                dict.Add("inventory", Inventory);
+            }
             if (JobType != null)
             {
                 dict.Add("job_type", $"{JobType}".ToLowerInvariant());
@@ -101,10 +108,11 @@ namespace AWX.Cmdlets
             var (fixedColor, implicitColor, explicitColor) = ((ConsoleColor?)null, ConsoleColor.Magenta, ConsoleColor.Green);
             WriteHost($"[{jt.Id}] {jt.Name} - {jt.Description}\n");
             var fmt = "{0,22} : {1}\n";
-            if (def.Inventory.Id != null)
             {
-                WriteHost(string.Format(fmt, "Inventory", $"[{def.Inventory.Id}] {def.Inventory.Name}"),
-                            foregroundColor: requirements.AskInventoryOnLaunch ? implicitColor: fixedColor);
+                var inventoryVal = (def.Inventory.Id != null ? $"[{def.Inventory.Id}] {def.Inventory.Name}" : "Undefined")
+                                   + (requirements.AskInventoryOnLaunch && Inventory != null ? $" => [{Inventory}]" : "");
+                WriteHost(string.Format(fmt, "Inventory", inventoryVal),
+                            foregroundColor: requirements.AskInventoryOnLaunch ? (Inventory == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.Limit) || Limit != null)
             {

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -116,6 +116,10 @@ namespace AWX.Cmdlets
         [Parameter()]
         public ulong? ExecutionEnvironment { get; set; }
 
+        [Parameter()]
+        [ValidateRange(0, int.MaxValue)]
+        public int? JobSliceCount { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -170,6 +174,10 @@ namespace AWX.Cmdlets
             if (ExecutionEnvironment != null)
             {
                 dict.Add("execution_environment", ExecutionEnvironment);
+            }
+            if (JobSliceCount != null)
+            {
+                dict.Add("job_slice_count", JobSliceCount);
             }
             return dict;
         }
@@ -280,8 +288,12 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Forks", forksVal),
                                 foregroundColor: requirements.AskForksOnLaunch ? (Forks == null ? implicitColor : explicitColor) : fixedColor);
             }
-            WriteHost(string.Format(fmt, "Job Slice Count", def.JobSliceCount),
-                            foregroundColor: requirements.AskJobSliceCountOnLaunch ? implicitColor : fixedColor);
+            {
+                var jobSliceVal = $"{def.JobSliceCount}"
+                                  + (requirements.AskJobSliceCountOnLaunch && JobSliceCount != null ? $" => {JobSliceCount}" : "");
+                WriteHost(string.Format(fmt, "Job Slice Count", jobSliceVal),
+                                foregroundColor: requirements.AskJobSliceCountOnLaunch ? (JobSliceCount == null ? implicitColor : explicitColor) : fixedColor);
+            }
             WriteHost(string.Format(fmt, "Timeout", def.Timeout),
                             foregroundColor: requirements.AskTimeoutOnLaunch ? implicitColor : fixedColor);
         }

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -120,6 +120,9 @@ namespace AWX.Cmdlets
         [ValidateRange(0, int.MaxValue)]
         public int? JobSliceCount { get; set; }
 
+        [Parameter()]
+        public int? Timeout { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -178,6 +181,10 @@ namespace AWX.Cmdlets
             if (JobSliceCount != null)
             {
                 dict.Add("job_slice_count", JobSliceCount);
+            }
+            if (Timeout != null)
+            {
+                dict.Add("timeout", Timeout);
             }
             return dict;
         }
@@ -294,8 +301,12 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Job Slice Count", jobSliceVal),
                                 foregroundColor: requirements.AskJobSliceCountOnLaunch ? (JobSliceCount == null ? implicitColor : explicitColor) : fixedColor);
             }
-            WriteHost(string.Format(fmt, "Timeout", def.Timeout),
-                            foregroundColor: requirements.AskTimeoutOnLaunch ? implicitColor : fixedColor);
+            {
+                var timeoutVal = $"{def.Timeout}"
+                                 + (requirements.AskTimeoutOnLaunch && Timeout != null ? $" => {Timeout}" : "");
+                WriteHost(string.Format(fmt, "Timeout", timeoutVal),
+                                foregroundColor: requirements.AskTimeoutOnLaunch ? (Timeout == null ? implicitColor : explicitColor) : fixedColor);
+            }
         }
         protected JobTemplateJob.LaunchResult? Launch(ulong id)
         {

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -91,6 +91,12 @@ namespace AWX.Cmdlets
         [Parameter()] // XXX: Should be string[] and created if not exists ?
         public ulong[]? Labels { get; set; }
 
+        [Parameter()]
+        public string[]? Tags { get; set; }
+
+        [Parameter()]
+        public string[]? SkipTags { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -113,6 +119,14 @@ namespace AWX.Cmdlets
             if (Labels != null)
             {
                 dict.Add("labels", Labels);
+            }
+            if (Tags != null)
+            {
+                dict.Add("job_tags", string.Join(',', Tags));
+            }
+            if (SkipTags != null)
+            {
+                dict.Add("skip_tags", string.Join(',', SkipTags));
             }
             return dict;
         }
@@ -150,15 +164,19 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Labels", labelsVal),
                             foregroundColor: requirements.AskLabelsOnLaunch ? (Labels ==  null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (!string.IsNullOrEmpty(def.JobTags))
+            if (!string.IsNullOrEmpty(def.JobTags) || Tags != null)
             {
-                WriteHost(string.Format(fmt, "Job tags", def.JobTags),
-                            foregroundColor: requirements.AskTagsOnLaunch ? implicitColor : fixedColor);
+                var tagsVal = def.JobTags
+                              + (requirements.AskTagsOnLaunch && Tags != null ? $" => {string.Join(", ", Tags)}" : "");
+                WriteHost(string.Format(fmt, "Job tags", tagsVal),
+                            foregroundColor: requirements.AskTagsOnLaunch ? (Tags == null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (!string.IsNullOrEmpty(def.SkipTags))
+            if (!string.IsNullOrEmpty(def.SkipTags) || SkipTags != null)
             {
-                WriteHost(string.Format(fmt, "Skip tags", def.SkipTags),
-                            foregroundColor: requirements.AskSkipTagsOnLaunch ? implicitColor : fixedColor);
+                var skipTagsVal = def.SkipTags
+                                  + (requirements.AskSkipTagsOnLaunch && SkipTags != null ? $" => {string.Join(", ", SkipTags)}" : "");
+                WriteHost(string.Format(fmt, "Skip tags", skipTagsVal),
+                            foregroundColor: requirements.AskSkipTagsOnLaunch ? (SkipTags == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.ExtraVars))
             {

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -100,6 +100,9 @@ namespace AWX.Cmdlets
         [Parameter()] // TODO: Should accept `IDctionary` (convert to JSON serialized string)
         public string? ExtraVars { get; set; }
 
+        [Parameter()]
+        public bool? DiffMode { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -134,6 +137,10 @@ namespace AWX.Cmdlets
             if (!string.IsNullOrEmpty(ExtraVars))
             {
                 dict.Add("extra_vars", ExtraVars);
+            }
+            if (DiffMode != null)
+            {
+                dict.Add("diff_mode", DiffMode);
             }
             return dict;
         }
@@ -207,8 +214,12 @@ namespace AWX.Cmdlets
                 WriteHost(sb.ToString(),
                             foregroundColor: requirements.AskVariablesOnLaunch ? (ExtraVars == null ? implicitColor : explicitColor) : fixedColor);
             }
-            WriteHost(string.Format(fmt, "Diff Mode", def.DiffMode),
-                            foregroundColor: requirements.AskDiffModeOnLaunch ? implicitColor : fixedColor);
+            {
+                var diffModeVal = $"{def.DiffMode}"
+                                  + (requirements.AskDiffModeOnLaunch && DiffMode != null ? $" => {DiffMode}" : "");
+                WriteHost(string.Format(fmt, "Diff Mode", diffModeVal),
+                                foregroundColor: requirements.AskDiffModeOnLaunch ? (DiffMode == null ? implicitColor : explicitColor) : fixedColor);
+            }
             {
                 var jobTypeVal = def.JobType
                                  + (requirements.AskJobTypeOnLaunch && JobType != null ? $" => {JobType}" : "");

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -87,6 +87,9 @@ namespace AWX.Cmdlets
         [Parameter()]
         public string? Limit { get; set; }
 
+        [Parameter()] // XXX: Should be string[] and created if not exists ?
+        public ulong[]? Labels { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -105,6 +108,10 @@ namespace AWX.Cmdlets
             if (Limit != null)
             {
                 dict.Add("limit", Limit);
+            }
+            if (Labels != null)
+            {
+                dict.Add("labels", Labels);
             }
             return dict;
         }
@@ -135,10 +142,12 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Scm Branch", branchVal),
                             foregroundColor: requirements.AskScmBranchOnLaunch ? (ScmBranch == null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (def.Labels != null && def.Labels.Length > 0)
+            if ((def.Labels != null && def.Labels.Length > 0) || Labels != null)
             {
-                WriteHost(string.Format(fmt, "Labels", string.Join(", ", def.Labels.Select(l => $"[{l.Id}] {l.Name}"))),
-                            foregroundColor: requirements.AskLabelsOnLaunch ? implicitColor : fixedColor);
+                var labelsVal = string.Join(", ", def.Labels?.Select(l => $"[{l.Id}] {l.Name}") ?? [])
+                                + (requirements.AskLabelsOnLaunch && Labels != null ? $" => {string.Join(',', Labels.Select(id => $"[{id}]"))}" : "");
+                WriteHost(string.Format(fmt, "Labels", labelsVal),
+                            foregroundColor: requirements.AskLabelsOnLaunch ? (Labels ==  null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.JobTags))
             {

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -100,8 +100,8 @@ namespace AWX.Cmdlets
             }
             if (!string.IsNullOrEmpty(def.Limit) || Limit != null)
             {
-                var limitVal = def.Limit + (Limit != null ? $" => {Limit}" : "");
-
+                var limitVal = def.Limit
+                               + (requirements.AskLimitOnLaunch && Limit != null ? $" => {Limit}" : "");
                 WriteHost(string.Format(fmt, "Limit", $"{limitVal}"),
                             foregroundColor: requirements.AskLimitOnLaunch ? (Limit == null ? implicitColor : explicitColor) : fixedColor);
             }

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -113,6 +113,9 @@ namespace AWX.Cmdlets
         [ValidateRange(0, int.MaxValue)]
         public int? Forks { get; set; }
 
+        [Parameter()]
+        public ulong? ExecutionEnvironment { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -163,6 +166,10 @@ namespace AWX.Cmdlets
             if (Forks != null)
             {
                 dict.Add("forks", Forks);
+            }
+            if (ExecutionEnvironment != null)
+            {
+                dict.Add("execution_environment", ExecutionEnvironment);
             }
             return dict;
         }
@@ -261,10 +268,12 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Credentials", credentialsVal),
                             foregroundColor: requirements.AskCredentialOnLaunch ? (Credentials == null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (def.ExecutionEnvironment.Id != null)
+            if (def.ExecutionEnvironment.Id != null || ExecutionEnvironment != null)
             {
-                WriteHost(string.Format(fmt, "ExecutionEnvironment", $"[{def.ExecutionEnvironment.Id}] {def.ExecutionEnvironment.Name}"),
-                            foregroundColor: requirements.AskExecutionEnvironmentOnLaunch ? implicitColor : fixedColor);
+                var eeVal = $"[{def.ExecutionEnvironment.Id}] {def.ExecutionEnvironment.Name}"
+                            + (requirements.AskExecutionEnvironmentOnLaunch && ExecutionEnvironment != null ? $" => [{ExecutionEnvironment}]" : "");
+                WriteHost(string.Format(fmt, "ExecutionEnvironment", eeVal),
+                            foregroundColor: requirements.AskExecutionEnvironmentOnLaunch ? (ExecutionEnvironment == null ? implicitColor : explicitColor) : fixedColor);
             }
             {
                 var forksVal = $"{def.Forks}" + (requirements.AskForksOnLaunch && Forks != null ? $" => {Forks}" : "");

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -82,6 +82,9 @@ namespace AWX.Cmdlets
         public JobType? JobType { get; set; }
 
         [Parameter()]
+        public string? ScmBranch { get; set; }
+
+        [Parameter()]
         public string? Limit { get; set; }
 
         private Hashtable CreateSendData()
@@ -94,6 +97,10 @@ namespace AWX.Cmdlets
             if (JobType != null)
             {
                 dict.Add("job_type", $"{JobType}".ToLowerInvariant());
+            }
+            if (ScmBranch != null)
+            {
+                dict.Add("scm_branch", ScmBranch);
             }
             if (Limit != null)
             {
@@ -121,10 +128,12 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Limit", $"{limitVal}"),
                             foregroundColor: requirements.AskLimitOnLaunch ? (Limit == null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (!string.IsNullOrEmpty(def.ScmBranch))
+            if (!string.IsNullOrEmpty(def.ScmBranch) || ScmBranch != null)
             {
-                WriteHost(string.Format(fmt, "Scm Branch", def.ScmBranch),
-                            foregroundColor: requirements.AskScmBranchOnLaunch? implicitColor : fixedColor);
+                var branchVal = def.ScmBranch
+                                + (requirements.AskScmBranchOnLaunch && ScmBranch != null ? $" => {ScmBranch}" : "");
+                WriteHost(string.Format(fmt, "Scm Branch", branchVal),
+                            foregroundColor: requirements.AskScmBranchOnLaunch ? (ScmBranch == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (def.Labels != null && def.Labels.Length > 0)
             {

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -97,6 +97,9 @@ namespace AWX.Cmdlets
         [Parameter()]
         public string[]? SkipTags { get; set; }
 
+        [Parameter()] // TODO: Should accept `IDctionary` (convert to JSON serialized string)
+        public string? ExtraVars { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -127,6 +130,10 @@ namespace AWX.Cmdlets
             if (SkipTags != null)
             {
                 dict.Add("skip_tags", string.Join(',', SkipTags));
+            }
+            if (!string.IsNullOrEmpty(ExtraVars))
+            {
+                dict.Add("extra_vars", ExtraVars);
             }
             return dict;
         }
@@ -178,17 +185,27 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Skip tags", skipTagsVal),
                             foregroundColor: requirements.AskSkipTagsOnLaunch ? (SkipTags == null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (!string.IsNullOrEmpty(def.ExtraVars))
+            if (!string.IsNullOrEmpty(def.ExtraVars) || !string.IsNullOrEmpty(ExtraVars))
             {
                 var sb = new StringBuilder();
                 var lines = def.ExtraVars.Split('\n');
+                var padding = "".PadLeft(25);
                 sb.Append(string.Format(fmt, "Extra vars", lines[0]));
                 foreach (var line in lines[1..])
                 {
-                    sb.AppendLine("".PadLeft(25) + line);
+                    sb.AppendLine(padding + line);
+                }
+                if (!string.IsNullOrEmpty(ExtraVars))
+                {
+                    sb.AppendLine($"{padding}=> (overwrite or append)");
+                    lines = ExtraVars.Split('\n');
+                    foreach (var line in lines)
+                    {
+                        sb.AppendLine(padding + line);
+                    }
                 }
                 WriteHost(sb.ToString(),
-                            foregroundColor: requirements.AskVariablesOnLaunch ? implicitColor : fixedColor);
+                            foregroundColor: requirements.AskVariablesOnLaunch ? (ExtraVars == null ? implicitColor : explicitColor) : fixedColor);
             }
             WriteHost(string.Format(fmt, "Diff Mode", def.DiffMode),
                             foregroundColor: requirements.AskDiffModeOnLaunch ? implicitColor : fixedColor);

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -109,6 +109,10 @@ namespace AWX.Cmdlets
         [Parameter()]
         public JobVerbosity? Verbosity { get; set; }
 
+        [Parameter()]
+        [ValidateRange(0, int.MaxValue)]
+        public int? Forks { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -155,6 +159,10 @@ namespace AWX.Cmdlets
             if (Verbosity != null)
             {
                 dict.Add("verbosity", (int)Verbosity);
+            }
+            if (Forks != null)
+            {
+                dict.Add("forks", Forks);
             }
             return dict;
         }
@@ -258,8 +266,11 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "ExecutionEnvironment", $"[{def.ExecutionEnvironment.Id}] {def.ExecutionEnvironment.Name}"),
                             foregroundColor: requirements.AskExecutionEnvironmentOnLaunch ? implicitColor : fixedColor);
             }
-            WriteHost(string.Format(fmt, "Forks", def.Forks),
-                            foregroundColor: requirements.AskForksOnLaunch ? implicitColor : fixedColor);
+            {
+                var forksVal = $"{def.Forks}" + (requirements.AskForksOnLaunch && Forks != null ? $" => {Forks}" : "");
+                WriteHost(string.Format(fmt, "Forks", forksVal),
+                                foregroundColor: requirements.AskForksOnLaunch ? (Forks == null ? implicitColor : explicitColor) : fixedColor);
+            }
             WriteHost(string.Format(fmt, "Job Slice Count", def.JobSliceCount),
                             foregroundColor: requirements.AskJobSliceCountOnLaunch ? implicitColor : fixedColor);
             WriteHost(string.Format(fmt, "Timeout", def.Timeout),

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -98,13 +98,15 @@ namespace AWX.Cmdlets
             var fmt = "{0,22} : {1}\n";
             if (def.Inventory.Id != null || Inventory != null)
             {
-                var inventoryVal = $"[{def.Inventory.Id}] {def.Inventory.Name}" + (Inventory != null ? $" => {Inventory}" : "");
+                var inventoryVal = $"[{def.Inventory.Id}] {def.Inventory.Name}"
+                                   + (requirements.AskInventoryOnLaunch && Inventory != null ? $" => {Inventory}" : "");
                 WriteHost(string.Format(fmt, "Inventory", inventoryVal),
                             foregroundColor: requirements.AskInventoryOnLaunch ? (Inventory == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.Limit) || Limit != null)
             {
-                var limitVal = def.Limit + (Limit != null ? $" => {Limit}" : "");
+                var limitVal = def.Limit
+                               + (requirements.AskLimitOnLaunch && Limit != null ? $" => {Limit}" : "");
                 WriteHost(string.Format(fmt, "Limit", limitVal),
                             foregroundColor: requirements.AskLimitOnLaunch ? (Limit == null ? implicitColor : explicitColor) : fixedColor);
             }

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -2,6 +2,7 @@ using AWX.Resources;
 using System.Collections;
 using System.Management.Automation;
 using System.Text;
+using System.Text.Json;
 
 namespace AWX.Cmdlets
 {
@@ -176,7 +177,7 @@ namespace AWX.Cmdlets
             {
                 foreach (var (key ,val) in launchResult.IgnoredFields)
                 {
-                    WriteWarning($"Ignored field: {key} ({val})");
+                    WriteWarning($"Ignored field: {key} ({JsonSerializer.Serialize(val, Json.DeserializeOptions)})");
                 }
             }
             return launchResult;

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -93,41 +93,40 @@ namespace AWX.Cmdlets
         {
             var wjt = requirements.WorkflowJobTemplateData;
             var def = requirements.Defaults;
-            var explicitColor = ConsoleColor.Green;
-            var askColor = ConsoleColor.Magenta;
+            var (fixedColor, implicitColor, explicitColor) = ((ConsoleColor?)null, ConsoleColor.Magenta, ConsoleColor.Green);
             WriteHost($"[{wjt.Id}] {wjt.Name} - {wjt.Description}\n");
             var fmt = "{0,22} : {1}\n";
             if (def.Inventory.Id != null || Inventory != null)
             {
                 var inventoryVal = $"[{def.Inventory.Id}] {def.Inventory.Name}" + (Inventory != null ? $" => {Inventory}" : "");
                 WriteHost(string.Format(fmt, "Inventory", inventoryVal),
-                            foregroundColor: requirements.AskInventoryOnLaunch ? Inventory == null ? askColor : explicitColor : null);
+                            foregroundColor: requirements.AskInventoryOnLaunch ? (Inventory == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.Limit) || Limit != null)
             {
                 var limitVal = def.Limit + (Limit != null ? $" => {Limit}" : "");
                 WriteHost(string.Format(fmt, "Limit", limitVal),
-                            foregroundColor: requirements.AskLimitOnLaunch ? Limit == null ? askColor : explicitColor : null);
+                            foregroundColor: requirements.AskLimitOnLaunch ? (Limit == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.ScmBranch))
             {
                 WriteHost(string.Format(fmt, "Scm Branch", def.ScmBranch),
-                            foregroundColor: requirements.AskScmBranchOnLaunch? askColor : explicitColor);
+                            foregroundColor: requirements.AskScmBranchOnLaunch? implicitColor : explicitColor);
             }
             if (def.Labels != null && def.Labels.Length > 0)
             {
                 WriteHost(string.Format(fmt, "Labels", string.Join(", ", def.Labels.Select(l => $"[{l.Id}] {l.Name}"))),
-                            foregroundColor: requirements.AskLabelsOnLaunch ? askColor : explicitColor);
+                            foregroundColor: requirements.AskLabelsOnLaunch ? implicitColor : explicitColor);
             }
             if (!string.IsNullOrEmpty(def.JobTags))
             {
                 WriteHost(string.Format(fmt, "Job tags", def.JobTags),
-                            foregroundColor: requirements.AskTagsOnLaunch ? askColor : explicitColor);
+                            foregroundColor: requirements.AskTagsOnLaunch ? implicitColor : explicitColor);
             }
             if (!string.IsNullOrEmpty(def.SkipTags))
             {
                 WriteHost(string.Format(fmt, "Skip tags", def.SkipTags),
-                            foregroundColor: requirements.AskSkipTagsOnLaunch ? askColor : explicitColor);
+                            foregroundColor: requirements.AskSkipTagsOnLaunch ? implicitColor : explicitColor);
             }
             if (!string.IsNullOrEmpty(def.ExtraVars))
             {
@@ -139,7 +138,7 @@ namespace AWX.Cmdlets
                     sb.AppendLine("".PadLeft(25) + line);
                 }
                 WriteHost(sb.ToString(),
-                            foregroundColor: requirements.AskVariablesOnLaunch ? askColor : explicitColor);
+                            foregroundColor: requirements.AskVariablesOnLaunch ? implicitColor : explicitColor);
             }
         }
         protected WorkflowJob.LaunchResult? Launch(ulong id)

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -74,6 +74,12 @@ namespace AWX.Cmdlets
         [Parameter()] // XXX: Should be string[] and created if not exists ?
         public ulong[]? Labels { get; set; }
 
+        [Parameter()]
+        public string[]? Tags { get; set; }
+
+        [Parameter()]
+        public string[]? SkipTags { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -92,6 +98,14 @@ namespace AWX.Cmdlets
             if (Labels != null)
             {
                 dict.Add("labels", Labels);
+            }
+            if (Tags != null)
+            {
+                dict.Add("job_tags", string.Join(',', Tags));
+            }
+            if (SkipTags != null)
+            {
+                dict.Add("skip_tags", string.Join(',', SkipTags));
             }
             return dict;
         }
@@ -139,15 +153,19 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Labels", labelsVal),
                             foregroundColor: requirements.AskLabelsOnLaunch ? (Labels ==  null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (!string.IsNullOrEmpty(def.JobTags))
+            if (!string.IsNullOrEmpty(def.JobTags) || Tags != null)
             {
-                WriteHost(string.Format(fmt, "Job tags", def.JobTags),
-                            foregroundColor: requirements.AskTagsOnLaunch ? implicitColor : explicitColor);
+                var tagsVal = def.JobTags
+                              + (requirements.AskTagsOnLaunch && Tags != null ? $" => {string.Join(", ", Tags)}" : "");
+                WriteHost(string.Format(fmt, "Job tags", tagsVal),
+                            foregroundColor: requirements.AskTagsOnLaunch ? (Tags == null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (!string.IsNullOrEmpty(def.SkipTags))
+            if (!string.IsNullOrEmpty(def.SkipTags) || SkipTags != null)
             {
-                WriteHost(string.Format(fmt, "Skip tags", def.SkipTags),
-                            foregroundColor: requirements.AskSkipTagsOnLaunch ? implicitColor : explicitColor);
+                var skipTagsVal = def.SkipTags
+                                  + (requirements.AskSkipTagsOnLaunch && SkipTags != null ? $" => {string.Join(", ", SkipTags)}" : "");
+                WriteHost(string.Format(fmt, "Skip tags", skipTagsVal),
+                            foregroundColor: requirements.AskSkipTagsOnLaunch ? (SkipTags == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.ExtraVars))
             {

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -67,12 +67,19 @@ namespace AWX.Cmdlets
         [Parameter()]
         public ulong? Inventory { get; set; }
 
+        [Parameter()]
+        public string? ScmBranch { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
             if (Inventory != null)
             {
                 dict.Add("inventory", Inventory);
+            }
+            if (ScmBranch != null)
+            {
+                dict.Add("scm_branch", ScmBranch);
             }
             if (Limit != null)
             {
@@ -110,10 +117,12 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Limit", limitVal),
                             foregroundColor: requirements.AskLimitOnLaunch ? (Limit == null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (!string.IsNullOrEmpty(def.ScmBranch))
+            if (!string.IsNullOrEmpty(def.ScmBranch) || ScmBranch != null)
             {
-                WriteHost(string.Format(fmt, "Scm Branch", def.ScmBranch),
-                            foregroundColor: requirements.AskScmBranchOnLaunch? implicitColor : explicitColor);
+                var branchVal = def.ScmBranch
+                                + (requirements.AskScmBranchOnLaunch && ScmBranch != null ? $" => {ScmBranch}" : "");
+                WriteHost(string.Format(fmt, "Scm Branch", branchVal),
+                            foregroundColor: requirements.AskScmBranchOnLaunch ? (ScmBranch == null ? implicitColor : explicitColor) : fixedColor);
             }
             if (def.Labels != null && def.Labels.Length > 0)
             {

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -70,6 +70,9 @@ namespace AWX.Cmdlets
         [Parameter()]
         public string? ScmBranch { get; set; }
 
+        [Parameter()] // XXX: Should be string[] and created if not exists ?
+        public ulong[]? Labels { get; set; }
+
         private Hashtable CreateSendData()
         {
             var dict = new Hashtable();
@@ -84,6 +87,10 @@ namespace AWX.Cmdlets
             if (Limit != null)
             {
                 dict.Add("limit", Limit);
+            }
+            if (Labels != null)
+            {
+                dict.Add("labels", Labels);
             }
             return dict;
         }
@@ -124,10 +131,12 @@ namespace AWX.Cmdlets
                 WriteHost(string.Format(fmt, "Scm Branch", branchVal),
                             foregroundColor: requirements.AskScmBranchOnLaunch ? (ScmBranch == null ? implicitColor : explicitColor) : fixedColor);
             }
-            if (def.Labels != null && def.Labels.Length > 0)
+            if ((def.Labels != null && def.Labels.Length > 0) || Labels != null)
             {
-                WriteHost(string.Format(fmt, "Labels", string.Join(", ", def.Labels.Select(l => $"[{l.Id}] {l.Name}"))),
-                            foregroundColor: requirements.AskLabelsOnLaunch ? implicitColor : explicitColor);
+                var labelsVal = string.Join(", ", def.Labels?.Select(l => $"[{l.Id}] {l.Name}") ?? [])
+                                + (requirements.AskLabelsOnLaunch && Labels != null ? $" => {string.Join(',', Labels.Select(id => $"[{id}]"))}" : "");
+                WriteHost(string.Format(fmt, "Labels", labelsVal),
+                            foregroundColor: requirements.AskLabelsOnLaunch ? (Labels ==  null ? implicitColor : explicitColor) : fixedColor);
             }
             if (!string.IsNullOrEmpty(def.JobTags))
             {


### PR DESCRIPTION
Add parameters to JobTemplate and WorkflowJobTempalte launcher

# JobTemplate (`Start-JobTemplate`, `Invoke-JobTemplate`)

- [x] `Inventory` parameter
- [x] `Limit` parameter (Already implemented)
- [x] `JobType` parameter
- [x] `ScmBranch` parameter
- [x] `Labels` parameter
- [x] `Tags` parameter
- [x] `SkipTags` parameter
- [x] `ExtraVars` parameter
- [x] `DiffMode` parameter
- [x] `Credentials` parameter
- [x] `Verbosity` parameter
- [x] `ExecutionEnvironment` parameter
- [x] `Forks` parameter
- [x] `JobSliceCount` parameter
- [x] `Timeout` parameter

# WorkflowJobTemplate (`Start-WorkflowJobTemplate`, `Invoke-WorkflowJobTemplate`)

- [x] `Inventory` parameter (Already implemented)
- [x] `Limit` parameter (Already implemented)
- [x] `ScmBranch` parameter
- [x] `Labels` parameter
- [x] `Tags` parameter
- [x] `SkipTags` parameter
- [x] `ExtraVars` parameter
