### PR TITLE
:art: Add `Id` and `Type` properties to each field in `SummaryFields`

### DIFF
--- a/src/Resources/AdHocCommandJobEvent.cs
+++ b/src/Resources/AdHocCommandJobEvent.cs
@@ -41,7 +41,7 @@ namespace AWX.Resources
             }
         }
 
-        public record Summary(NameDescriptionSummary Host);
+        public record Summary(HostSummary Host);
 
         public ulong Id { get; } = id;
         public ResourceType Type { get; } = type;

--- a/src/Resources/Application.cs
+++ b/src/Resources/Application.cs
@@ -135,9 +135,9 @@ namespace AWX.Resources
             }
         }
 
-        public record Summary(NameDescriptionSummary Organization,
-                                               [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
-                                               ListSummary<TokenSummary> Tokens);
+        public record Summary(OrganizationSummary Organization,
+                              [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
+                              ListSummary<TokenSummary> Tokens);
 
         public ulong Id { get; } = id;
         public ResourceType Type { get; } = type;

--- a/src/Resources/Credential.cs
+++ b/src/Resources/Credential.cs
@@ -334,7 +334,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("credential_type")] CredentialTypeSummary CredentialType,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
-            [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
+            [property: JsonPropertyName("object_roles")] Dictionary<string, ObjectRoleSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
             OwnerSummary[] Owners);
 

--- a/src/Resources/Credential.cs
+++ b/src/Resources/Credential.cs
@@ -330,7 +330,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary? Organization,
+            OrganizationSummary? Organization,
             [property: JsonPropertyName("credential_type")] NameDescriptionSummary CredentialType,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,

--- a/src/Resources/Credential.cs
+++ b/src/Resources/Credential.cs
@@ -331,7 +331,7 @@ namespace AWX.Resources
 
         public record Summary(
             OrganizationSummary? Organization,
-            [property: JsonPropertyName("credential_type")] NameDescriptionSummary CredentialType,
+            [property: JsonPropertyName("credential_type")] CredentialTypeSummary CredentialType,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
             [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,

--- a/src/Resources/ExecutionEnvironment.cs
+++ b/src/Resources/ExecutionEnvironment.cs
@@ -103,7 +103,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary? Organization,
+            OrganizationSummary? Organization,
             [property: JsonPropertyName("created_by")] UserSummary? CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities

--- a/src/Resources/Host.cs
+++ b/src/Resources/Host.cs
@@ -164,7 +164,7 @@ namespace AWX.Resources
 
         public record Summary(
             InventorySummary Inventory,
-            [property: JsonPropertyName("last_job")] JobExSummary? LastJob,
+            [property: JsonPropertyName("last_job")] HostLastJobSummary? LastJob,
             [property: JsonPropertyName("last_job_host_summary")] LastJobHostSummary? LastJobHostSummary,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
             ListSummary<GroupSummary> Groups,

--- a/src/Resources/Host.cs
+++ b/src/Resources/Host.cs
@@ -167,7 +167,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("last_job")] JobExSummary? LastJob,
             [property: JsonPropertyName("last_job_host_summary")] LastJobHostSummary? LastJobHostSummary,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
-            ListSummary<NameSummary> Groups,
+            ListSummary<GroupSummary> Groups,
             [property: JsonPropertyName("recent_jobs")] HostRecentJobSummary[] RecentJobs);
 
 

--- a/src/Resources/InstanceGroup.cs
+++ b/src/Resources/InstanceGroup.cs
@@ -225,7 +225,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
+            [property: JsonPropertyName("object_roles")] Dictionary<string, ObjectRoleSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities);
 
 

--- a/src/Resources/Inventory.cs
+++ b/src/Resources/Inventory.cs
@@ -140,7 +140,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
             [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
-            ListSummary<NameSummary> Labels);
+            ListSummary<LabelSummary> Labels);
 
         public ulong Id { get; } = id;
         public ResourceType Type { get; } = type;

--- a/src/Resources/Inventory.cs
+++ b/src/Resources/Inventory.cs
@@ -135,7 +135,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
             [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,

--- a/src/Resources/Inventory.cs
+++ b/src/Resources/Inventory.cs
@@ -138,7 +138,7 @@ namespace AWX.Resources
             OrganizationSummary Organization,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
-            [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
+            [property: JsonPropertyName("object_roles")] Dictionary<string, ObjectRoleSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
             ListSummary<LabelSummary> Labels);
 

--- a/src/Resources/InventorySource.cs
+++ b/src/Resources/InventorySource.cs
@@ -301,7 +301,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             InventorySummary Inventory,
             [property: JsonPropertyName("execution_environment")] EnvironmentSummary? ExecutionEnvironment,
             [property: JsonPropertyName("source_project")] ProjectSummary? SourceProject,

--- a/src/Resources/InventoryUpdateJob.cs
+++ b/src/Resources/InventoryUpdateJob.cs
@@ -204,7 +204,7 @@ namespace AWX.Resources
 
 
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             InventorySummary Inventory,
             [property: JsonPropertyName("execution_environment")] EnvironmentSummary? ExecutionEnvironment,
             CredentialSummary? Credential,

--- a/src/Resources/JobEvent.cs
+++ b/src/Resources/JobEvent.cs
@@ -1,5 +1,4 @@
 using System.Collections.Specialized;
-using System.Reflection;
 using System.Text.Json.Serialization;
 
 namespace AWX.Resources
@@ -214,7 +213,7 @@ namespace AWX.Resources
             }
         }
 
-        public record Summary(NameDescriptionSummary? Host, JobExSummary Job, OrderedDictionary Role);
+        public record Summary(HostSummary? Host, JobExSummary Job, OrderedDictionary Role);
 
         public ulong Id { get; } = id;
         public ResourceType Type { get; } = type;

--- a/src/Resources/JobHostSummary.cs
+++ b/src/Resources/JobHostSummary.cs
@@ -86,7 +86,7 @@ namespace AWX.Resources
             }
         }
 
-        public record Summary(NameDescriptionSummary Host, JobExSummary Job);
+        public record Summary(HostSummary Host, JobExSummary Job);
 
         public ulong Id { get; } = id;
         public ResourceType Type { get; } = type;

--- a/src/Resources/JobTemplate.cs
+++ b/src/Resources/JobTemplate.cs
@@ -262,7 +262,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
             [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
-            ListSummary<NameSummary> Labels,
+            ListSummary<LabelSummary> Labels,
             [property: JsonPropertyName("recent_jobs")] RecentJobSummary[] RecentJobs,
             JobTemplateCredentialSummary[] Credentials);
 

--- a/src/Resources/JobTemplate.cs
+++ b/src/Resources/JobTemplate.cs
@@ -260,7 +260,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("last_update")] LastUpdateSummary? LastUpdate,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
-            [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
+            [property: JsonPropertyName("object_roles")] Dictionary<string, ObjectRoleSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
             ListSummary<LabelSummary> Labels,
             [property: JsonPropertyName("recent_jobs")] RecentJobSummary[] RecentJobs,

--- a/src/Resources/JobTemplate.cs
+++ b/src/Resources/JobTemplate.cs
@@ -252,7 +252,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             InventorySummary? Inventory,
             ProjectSummary Project,
             [property: JsonPropertyName("execution_environment")] EnvironmentSummary? ExecutionEnvironment,

--- a/src/Resources/JobTemplateJob.cs
+++ b/src/Resources/JobTemplateJob.cs
@@ -135,7 +135,7 @@ namespace AWX.Resources
             InventorySummary Inventory,
             [property: JsonPropertyName("execution_environment")] EnvironmentSummary? ExecutionEnvironment,
             ProjectSummary Project,
-            [property: JsonPropertyName("job_template")] NameDescriptionSummary JobTemplate,
+            [property: JsonPropertyName("job_template")] JobTemplateSummary JobTemplate,
             ScheduleSummary? Schedule,
             [property: JsonPropertyName("unified_job_template")] UnifiedJobTemplateSummary UnifiedJobTemplate,
             [property: JsonPropertyName("instance_group")] InstanceGroupSummary InstanceGroup,

--- a/src/Resources/JobTemplateJob.cs
+++ b/src/Resources/JobTemplateJob.cs
@@ -141,7 +141,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("instance_group")] InstanceGroupSummary InstanceGroup,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
-            ListSummary<NameSummary> Labels,
+            ListSummary<LabelSummary> Labels,
             [property: JsonPropertyName("source_workflow_job")] WorkflowJobSummary? SourceWorkflowJob,
             [property: JsonPropertyName("ancestor_job")] AncestorJobSummary? AncestorJob,
             JobTemplateCredentialSummary[] Credentials);

--- a/src/Resources/JobTemplateJob.cs
+++ b/src/Resources/JobTemplateJob.cs
@@ -142,7 +142,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
             ListSummary<LabelSummary> Labels,
-            [property: JsonPropertyName("source_workflow_job")] WorkflowJobSummary? SourceWorkflowJob,
+            [property: JsonPropertyName("source_workflow_job")] SourceWorkflowJobSummary? SourceWorkflowJob,
             [property: JsonPropertyName("ancestor_job")] AncestorJobSummary? AncestorJob,
             JobTemplateCredentialSummary[] Credentials);
 

--- a/src/Resources/JobTemplateJob.cs
+++ b/src/Resources/JobTemplateJob.cs
@@ -131,7 +131,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             InventorySummary Inventory,
             [property: JsonPropertyName("execution_environment")] EnvironmentSummary? ExecutionEnvironment,
             ProjectSummary Project,

--- a/src/Resources/Label.cs
+++ b/src/Resources/Label.cs
@@ -56,7 +56,7 @@ namespace AWX.Resources
             }
         }
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             [property: JsonPropertyName("created_by")] UserSummary? CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy);
 

--- a/src/Resources/Notification.cs
+++ b/src/Resources/Notification.cs
@@ -58,7 +58,7 @@ namespace AWX.Resources
             }
         }
         public record Summary(
-            [property: JsonPropertyName("notification_template")] NameDescriptionSummary NotificationTemplate);
+            [property: JsonPropertyName("notification_template")] NotificationTemplateSummary NotificationTemplate);
 
 
         public ulong Id { get; } = id;

--- a/src/Resources/NotificationTemplate.cs
+++ b/src/Resources/NotificationTemplate.cs
@@ -83,7 +83,7 @@ namespace AWX.Resources
             }
         }
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary ModifiedBy,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,

--- a/src/Resources/OAuth2AccessToken.cs
+++ b/src/Resources/OAuth2AccessToken.cs
@@ -151,7 +151,7 @@ namespace AWX.Resources
             }
         }
 
-        public record Summary(UserSummary User, NameSummary? Application = null);
+        public record Summary(UserSummary User, ApplicationSummary? Application = null);
 
 
         public ulong Id { get; } = id;

--- a/src/Resources/Organization.cs
+++ b/src/Resources/Organization.cs
@@ -103,7 +103,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("default_environment")] EnvironmentSummary? DefaultEnvironment,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary ModifiedBy,
-            [property: JsonPropertyName("object_roles")] Dictionary<string, RoleSummary> ObjectRoles,
+            [property: JsonPropertyName("object_roles")] Dictionary<string, OrganizationObjectRoleSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
             [property: JsonPropertyName("related_field_counts")] RelatedFieldCountsSummary RelatedFieldCounts);
 

--- a/src/Resources/Project.cs
+++ b/src/Resources/Project.cs
@@ -227,7 +227,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("last_update")] LastUpdateSummary? LastUpdate,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary ModifiedBy,
-            [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
+            [property: JsonPropertyName("object_roles")] Dictionary<string, ObjectRoleSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities);
 
 

--- a/src/Resources/Project.cs
+++ b/src/Resources/Project.cs
@@ -220,7 +220,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             [property: JsonPropertyName("default_environment")] EnvironmentSummary? DefaultEnvironment,
             CredentialSummary? Credential,
             [property: JsonPropertyName("last_job")] LastJobSummary? LastJob,

--- a/src/Resources/ProjectUpdateJob.cs
+++ b/src/Resources/ProjectUpdateJob.cs
@@ -104,7 +104,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             [property: JsonPropertyName("default_environment")] EnvironmentSummary? DefaultEnvironment,
             ProjectSummary Project,
             CredentialSummary? Credential,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -327,7 +327,7 @@ namespace AWX.Resources
 
     // Owners in Credential
     public record OwnerSummary(ulong Id,
-                               string Type,
+                               ResourceType Type,
                                string Name,
                                string Description,
                                string Url)

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -52,15 +52,6 @@ namespace AWX.Resources
     public record LabelSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.Label);
 
-    // NotificationTemplate in Notification
-    public record NameDescriptionSummary(ulong Id,
-                                         string Name,
-                                         string Description)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
-
     // Host in AdHocCommandJobEvent, JobEvent, JobHostSummary
     public record HostSummary(ulong Id, string Name, string Description)
         : ResourceSummary(Id, ResourceType.Host);
@@ -81,6 +72,10 @@ namespace AWX.Resources
     // JobTemplate in Job
     public record JobTemplateSummary(ulong Id, string Name, string Description)
         : ResourceSummary(Id, ResourceType.JobTemplate);
+
+    // NotificationTemplate in Notification
+    public record NotificationTemplateSummary(ulong Id, string Name, string Description)
+        : ResourceSummary(Id, ResourceType.NotificationTemplate);
 
     // Actor in ActivityStream
     // CreatedBy in AdHocCommand, Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -79,7 +79,7 @@ namespace AWX.Resources
 
     // WorkflowJobTemplate in WorkflowApproval, WorkflowApprovalTemplate, WorkflowJob, WorkflowJobTemplateNode
     public record WorkflowJobTemplateSummary(ulong Id, string Name, string Description)
-        : ResourceSummary(Id, ResourceType.NotificationTemplate);
+        : ResourceSummary(Id, ResourceType.WorkflowJobTemplate);
 
     // WorkflowJob in WorkflowApproval, WorkflowJobNode
     public record WorkflowJobSummary(ulong Id, string Name, string Description)

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -318,10 +318,7 @@ namespace AWX.Resources
     public record InstanceGroupSummary(ulong Id,
                                        string Name,
                                        [property: JsonPropertyName("is_container_group")] bool IsContainerGroup)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.InstanceGroup);
 
     // Owners in Credential
     public record OwnerSummary(ulong Id,
@@ -329,38 +326,26 @@ namespace AWX.Resources
                                string Name,
                                string Description,
                                string Url)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, Type);
 
     // Schedule in InventoryUpdate, Job, ProjectUpdate, SystemJob, WorkflowJob
     public record ScheduleSummary(ulong Id,
                                   string Name,
                                   string Description,
                                   [property: JsonPropertyName("next_run")] DateTime NextRun)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.Schedule);
 
     // RecentNotification in NotificationTemplate
     public record RecentNotificationSummary(ulong Id,
                                             JobStatus Status,
                                             DateTime Created,
                                             string Error)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.Notification);
 
     // WorkflowApprovalTemplate in WorkflowApproval
     public record WorkflowApprovalTemplateSummary(ulong Id,
                                                   string Name,
                                                   string Description,
                                                   int Timeout)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.WorkflowApprovalTemplate);
 }

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -5,17 +5,6 @@ namespace AWX.Resources
 {
     public abstract record SummaryBase
     {
-        public override string ToString()
-        {
-            var sb = new StringBuilder();
-            sb.Append("{ ");
-            if (PrintMembers(sb)) sb.Append(' ');
-            sb.Append('}');
-            return sb.ToString();
-        }
-    }
-    public abstract record ResourceSummary(ulong Id, ResourceType Type)
-    {
         public sealed override string ToString()
         {
             var sb = new StringBuilder();
@@ -25,6 +14,7 @@ namespace AWX.Resources
             return sb.ToString();
         }
     }
+    public abstract record ResourceSummary(ulong Id, ResourceType Type) : SummaryBase;
 
     [JsonConverter(typeof(Json.CapabilityConverter))]
     [Flags]
@@ -123,10 +113,7 @@ namespace AWX.Resources
                                             [property: JsonPropertyName("job_templates")] int JobTemplates,
                                             int Admins,
                                             int Projects)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : SummaryBase;
 
     // List<Token> in Application
     public record TokenSummary(ulong Id,
@@ -136,10 +123,7 @@ namespace AWX.Resources
 
     public record ListSummary<T>(int Count,
                                  T[] Results)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : SummaryBase;
 
     // Credential in AdHocCommand, InventorySource, InventoryUpdate, Project, ProjectUpdate
     // SourceCredential in CredentialInputSource
@@ -168,10 +152,7 @@ namespace AWX.Resources
                                  DateTime? Finished,
                                  JobStatus Status,
                                  bool Failed)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : SummaryBase;
 
     // RecentJobs in Host
     public record HostRecentJobSummary(ulong Id,
@@ -249,10 +230,7 @@ namespace AWX.Resources
                                     string Description,
                                     JobStatus Status,
                                     bool Failed)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : SummaryBase;
 
     // Inventory in AdHocCommand, Group, Host, InventorySource, InventoryUpdate, JobTemplate, Job, Schedule, WorkflowJobTemplate
     public record InventorySummary(ulong Id,
@@ -303,7 +281,6 @@ namespace AWX.Resources
                                             [property: JsonPropertyName("unified_job_type")] ResourceType UnifiedJobType)
         : SummaryBase
     {
-        public override string ToString() => base.ToString();
         public ResourceType Type => UnifiedJobType switch {
             ResourceType.Job => ResourceType.JobTemplate,
             ResourceType.ProjectUpdate => ResourceType.Project,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -100,10 +100,7 @@ namespace AWX.Resources
     // ExecutionEnvironment in AdHocCommand, InventorySource, InventoryUpdate, JobTemplate, Job, SystemJob
     // DefaultEnvironment in Organization, Project, ProjectUpdate
     // ResolvedEnvironment in SystemJobTemplate, WorkflowApprovalTemplate
-    public record EnvironmentSummary(ulong Id,
-                                     string Name,
-                                     string Description,
-                                     string Image)
+    public record EnvironmentSummary(ulong Id, string Name, string Description, string Image)
         : ResourceSummary(Id, ResourceType.ExecutionEnvironment);
 
     // RelatedFieldCounts in Organization
@@ -116,13 +113,10 @@ namespace AWX.Resources
         : SummaryBase;
 
     // List<Token> in Application
-    public record TokenSummary(ulong Id,
-                               string Token,
-                               string Scope)
+    public record TokenSummary(ulong Id, string Token, string Scope)
         : ResourceSummary(Id, ResourceType.OAuth2AccessToken);
 
-    public record ListSummary<T>(int Count,
-                                 T[] Results)
+    public record ListSummary<T>(int Count, T[] Results)
         : SummaryBase;
 
     // Credential in AdHocCommand, InventorySource, InventoryUpdate, Project, ProjectUpdate
@@ -138,11 +132,7 @@ namespace AWX.Resources
         : ResourceSummary(Id, ResourceType.Credential);
 
     // Credentials in JobTemplate, Job
-    public record JobTemplateCredentialSummary(ulong Id,
-                                               string Name,
-                                               string Description,
-                                               string Kind,
-                                               bool Cloud)
+    public record JobTemplateCredentialSummary(ulong Id, string Name, string Description, string Kind, bool Cloud)
         : ResourceSummary(Id, ResourceType.Credential);
 
     // LastJob in InventorySource, JobTemplate, Project, SystemJobTemplate, WorkflowApprovalTemplate, WorkflowJobTemplate
@@ -155,11 +145,7 @@ namespace AWX.Resources
         : SummaryBase;
 
     // RecentJobs in Host
-    public record HostRecentJobSummary(ulong Id,
-                                       string Name,
-                                       ResourceType Type,
-                                       JobStatus Status,
-                                       DateTime? Finished)
+    public record HostRecentJobSummary(ulong Id, string Name, ResourceType Type, JobStatus Status, DateTime? Finished)
         : ResourceSummary(Id, Type);
 
     // RecentJobs in JobTemplate, WorkflowJobTemplate
@@ -213,23 +199,15 @@ namespace AWX.Resources
         : ResourceSummary(Id, ResourceType.WorkflowJob);
 
     // AncestorJob in Job
-    public record AncestorJobSummary(ulong Id,
-                                     string Name,
-                                     ResourceType Type,
-                                     string Url)
+    public record AncestorJobSummary(ulong Id, string Name, ResourceType Type, string Url)
         : ResourceSummary(Id, Type);
 
     // LastJobHostSummary in Host
-    public record LastJobHostSummary(ulong Id,
-                                     bool Failed)
+    public record LastJobHostSummary(ulong Id, bool Failed)
         : ResourceSummary(Id, ResourceType.JobHostSummary);
 
     // LastUpdate in InventorySource, JobTemplate, Project, SystemJobTemplate, WorkflowApprovalTemplate, WorkflowJobTemplate
-    public record LastUpdateSummary(ulong Id,
-                                    string Name,
-                                    string Description,
-                                    JobStatus Status,
-                                    bool Failed)
+    public record LastUpdateSummary(ulong Id, string Name, string Description, JobStatus Status, bool Failed)
         : SummaryBase;
 
     // Inventory in AdHocCommand, Group, Host, InventorySource, InventoryUpdate, JobTemplate, Job, Schedule, WorkflowJobTemplate
@@ -266,11 +244,7 @@ namespace AWX.Resources
         : ResourceSummary(Id, ResourceType.Project);
 
     // ProjectUpdate in ProjectUpdateJobEvent
-    public record ProjectUpdateSummary(ulong Id,
-                                       string Name,
-                                       string Description,
-                                       JobStatus Status,
-                                       bool Failed)
+    public record ProjectUpdateSummary(ulong Id, string Name, string Description, JobStatus Status, bool Failed)
         : ResourceSummary(Id, ResourceType.ProjectUpdate);
 
     // UnifiedJobTemplate in InventoryUpdate, Job, ProjectUpdate, Schedule, SystemJob, WorkflowApproval, WorkflowJob,
@@ -298,11 +272,7 @@ namespace AWX.Resources
         : ResourceSummary(Id, ResourceType.InstanceGroup);
 
     // Owners in Credential
-    public record OwnerSummary(ulong Id,
-                               ResourceType Type,
-                               string Name,
-                               string Description,
-                               string Url)
+    public record OwnerSummary(ulong Id, ResourceType Type, string Name, string Description, string Url)
         : ResourceSummary(Id, Type);
 
     // Schedule in InventoryUpdate, Job, ProjectUpdate, SystemJob, WorkflowJob
@@ -313,16 +283,10 @@ namespace AWX.Resources
         : ResourceSummary(Id, ResourceType.Schedule);
 
     // RecentNotification in NotificationTemplate
-    public record RecentNotificationSummary(ulong Id,
-                                            JobStatus Status,
-                                            DateTime Created,
-                                            string Error)
+    public record RecentNotificationSummary(ulong Id, JobStatus Status, DateTime Created, string Error)
         : ResourceSummary(Id, ResourceType.Notification);
 
     // WorkflowApprovalTemplate in WorkflowApproval
-    public record WorkflowApprovalTemplateSummary(ulong Id,
-                                                  string Name,
-                                                  string Description,
-                                                  int Timeout)
+    public record WorkflowApprovalTemplateSummary(ulong Id, string Name, string Description, int Timeout)
         : ResourceSummary(Id, ResourceType.WorkflowApprovalTemplate);
 }

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -304,6 +304,14 @@ namespace AWX.Resources
         : SummaryBase
     {
         public override string ToString() => base.ToString();
+        public ResourceType Type => UnifiedJobType switch {
+            ResourceType.Job => ResourceType.JobTemplate,
+            ResourceType.ProjectUpdate => ResourceType.Project,
+            ResourceType.InventoryUpdate => ResourceType.InventorySource,
+            ResourceType.WorkflowJob => ResourceType.WorkflowJobTemplate,
+            ResourceType.SystemJob => ResourceType.SystemJobTemplate,
+            _ => ResourceType.None
+        };
     }
 
     // InstanceGroup in AdHocCommand, InventoryUpdate, Job, ProjectUpdate, SystemJob

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -40,14 +40,6 @@ namespace AWX.Resources
         AdHoc = 1 << 6,
     }
 
-    // List<Label> in Inventory, Job, JobTemplate, WorkflowJob, WorkflowJobTemplate
-    public record NameSummary(ulong Id,
-                              string Name)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
-
     // Application in Token
     public record ApplicationSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.OAuth2Application);
@@ -55,6 +47,10 @@ namespace AWX.Resources
     // List<Group> in Host
     public record GroupSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.Group);
+
+    // List<Label> in Inventory, Job, JobTemplate, WorkflowJob, WorkflowJobTemplate
+    public record LabelSummary(ulong Id, string Name)
+        : ResourceSummary(Id, ResourceType.Label);
 
     // Host in AdHocCommandJobEvent, JobEvent, JobHostSummary
     // Organization in Application, Credential, ExecutionEnvironment, Inventory, InventorySource, InventoryUpdate,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -200,6 +200,16 @@ namespace AWX.Resources
         : ResourceSummary(Id, Type);
 
     // LastJob in Host
+    public record HostLastJobSummary(ulong Id,
+                                     string Name,
+                                     string Description,
+                                     JobStatus Status,
+                                     bool Failed,
+                                     double Elapsed,
+                                     [property: JsonPropertyName("job_template_id")] ulong JobTemplateId,
+                                     [property: JsonPropertyName("job_template_name")] string JobTemplateName)
+        : ResourceSummary(Id, ResourceType.Job);
+
     // Job in JobEvent, JobHostSummary
     public record JobExSummary(ulong Id,
                                string Name,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -40,7 +40,6 @@ namespace AWX.Resources
         AdHoc = 1 << 6,
     }
 
-    // Application in Token
     // List<Group> in Host
     // List<Label> in Inventory, Job, JobTemplate, WorkflowJob, WorkflowJobTemplate
     public record NameSummary(ulong Id,
@@ -49,6 +48,10 @@ namespace AWX.Resources
     {
         public override string ToString() => base.ToString();
     }
+
+    // Application in Token
+    public record ApplicationSummary(ulong Id, string Name)
+        : ResourceSummary(Id, ResourceType.OAuth2Application);
 
     // Host in AdHocCommandJobEvent, JobEvent, JobHostSummary
     // Organization in Application, Credential, ExecutionEnvironment, Inventory, InventorySource, InventoryUpdate,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -40,7 +40,6 @@ namespace AWX.Resources
         AdHoc = 1 << 6,
     }
 
-    // List<Group> in Host
     // List<Label> in Inventory, Job, JobTemplate, WorkflowJob, WorkflowJobTemplate
     public record NameSummary(ulong Id,
                               string Name)
@@ -52,6 +51,10 @@ namespace AWX.Resources
     // Application in Token
     public record ApplicationSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.OAuth2Application);
+
+    // List<Group> in Host
+    public record GroupSummary(ulong Id, string Name)
+        : ResourceSummary(Id, ResourceType.Group);
 
     // Host in AdHocCommandJobEvent, JobEvent, JobHostSummary
     // Organization in Application, Credential, ExecutionEnvironment, Inventory, InventorySource, InventoryUpdate,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -14,6 +14,17 @@ namespace AWX.Resources
             return sb.ToString();
         }
     }
+    public abstract record ResourceSummary(ulong Id, ResourceType Type)
+    {
+        public sealed override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("{ ");
+            if (PrintMembers(sb)) sb.Append(' ');
+            sb.Append('}');
+            return sb.ToString();
+        }
+    }
 
     [JsonConverter(typeof(Json.CapabilityConverter))]
     [Flags]

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -52,8 +52,6 @@ namespace AWX.Resources
     public record LabelSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.Label);
 
-    // Organization in Application, Credential, ExecutionEnvironment, Inventory, InventorySource, InventoryUpdate,
-    //                 JobTemplate, Job, Label, NotificationTemplate, Project, ProjectUpdate
     // CredentialType in Credential
     // ObjectRoles in Credential, InstanceGroup, Inventory, JobTemplate, Project
     // JobTemplate in Job
@@ -69,6 +67,11 @@ namespace AWX.Resources
     // Host in AdHocCommandJobEvent, JobEvent, JobHostSummary
     public record HostSummary(ulong Id, string Name, string Description)
         : ResourceSummary(Id, ResourceType.Host);
+
+    // Organization in Application, Credential, ExecutionEnvironment, Inventory, InventorySource, InventoryUpdate,
+    //                 JobTemplate, Job, Label, NotificationTemplate, Project, ProjectUpdate, Team, WorkflowJobtemplate
+    public record OrganizationSummary(ulong Id, string Name, string Description)
+        : ResourceSummary(Id, ResourceType.Organization);
 
     // Actor in ActivityStream
     // CreatedBy in AdHocCommand, Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -52,7 +52,6 @@ namespace AWX.Resources
     public record LabelSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.Label);
 
-    // ObjectRoles in Credential, InstanceGroup, Inventory, JobTemplate, Project
     // JobTemplate in Job
     // NotificationTemplate in Notification
     public record NameDescriptionSummary(ulong Id,
@@ -75,6 +74,10 @@ namespace AWX.Resources
     // CredentialType in Credential
     public record CredentialTypeSummary(ulong Id, string Name, string Description)
         : ResourceSummary(Id, ResourceType.CredentialType);
+
+    // ObjectRoles in Credential, InstanceGroup, Inventory, JobTemplate, Project, Team, WorkflowJobTemplate
+    public record ObjectRoleSummary(ulong Id, string Name, string Description)
+        : ResourceSummary(Id, ResourceType.Role);
 
     // Actor in ActivityStream
     // CreatedBy in AdHocCommand, Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -52,7 +52,6 @@ namespace AWX.Resources
     public record LabelSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.Label);
 
-    // Host in AdHocCommandJobEvent, JobEvent, JobHostSummary
     // Organization in Application, Credential, ExecutionEnvironment, Inventory, InventorySource, InventoryUpdate,
     //                 JobTemplate, Job, Label, NotificationTemplate, Project, ProjectUpdate
     // CredentialType in Credential
@@ -66,6 +65,10 @@ namespace AWX.Resources
     {
         public override string ToString() => base.ToString();
     }
+
+    // Host in AdHocCommandJobEvent, JobEvent, JobHostSummary
+    public record HostSummary(ulong Id, string Name, string Description)
+        : ResourceSummary(Id, ResourceType.Host);
 
     // Actor in ActivityStream
     // CreatedBy in AdHocCommand, Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -52,7 +52,6 @@ namespace AWX.Resources
     public record LabelSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.Label);
 
-    // CredentialType in Credential
     // ObjectRoles in Credential, InstanceGroup, Inventory, JobTemplate, Project
     // JobTemplate in Job
     // NotificationTemplate in Notification
@@ -72,6 +71,10 @@ namespace AWX.Resources
     //                 JobTemplate, Job, Label, NotificationTemplate, Project, ProjectUpdate, Team, WorkflowJobtemplate
     public record OrganizationSummary(ulong Id, string Name, string Description)
         : ResourceSummary(Id, ResourceType.Organization);
+
+    // CredentialType in Credential
+    public record CredentialTypeSummary(ulong Id, string Name, string Description)
+        : ResourceSummary(Id, ResourceType.CredentialType);
 
     // Actor in ActivityStream
     // CreatedBy in AdHocCommand, Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -52,7 +52,6 @@ namespace AWX.Resources
     public record LabelSummary(ulong Id, string Name)
         : ResourceSummary(Id, ResourceType.Label);
 
-    // JobTemplate in Job
     // NotificationTemplate in Notification
     public record NameDescriptionSummary(ulong Id,
                                          string Name,
@@ -78,6 +77,10 @@ namespace AWX.Resources
     // ObjectRoles in Credential, InstanceGroup, Inventory, JobTemplate, Project, Team, WorkflowJobTemplate
     public record ObjectRoleSummary(ulong Id, string Name, string Description)
         : ResourceSummary(Id, ResourceType.Role);
+
+    // JobTemplate in Job
+    public record JobTemplateSummary(ulong Id, string Name, string Description)
+        : ResourceSummary(Id, ResourceType.JobTemplate);
 
     // Actor in ActivityStream
     // CreatedBy in AdHocCommand, Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory,

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -1,7 +1,19 @@
+using System.Text;
 using System.Text.Json.Serialization;
 
 namespace AWX.Resources
 {
+    public abstract record SummaryBase
+    {
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("{ ");
+            if (PrintMembers(sb)) sb.Append(' ');
+            sb.Append('}');
+            return sb.ToString();
+        }
+    }
 
     [JsonConverter(typeof(Json.CapabilityConverter))]
     [Flags]
@@ -17,74 +29,174 @@ namespace AWX.Resources
         AdHoc = 1 << 6,
     }
 
-    public record NameSummary(ulong Id, string Name);
-    public record NameDescriptionSummary(ulong Id, string Name, string Description);
+    // Application in Token
+    // List<Group> in Host
+    // List<Label> in Inventory, Job, JobTemplate, WorkflowJob, WorkflowJobTemplate
+    public record NameSummary(ulong Id,
+                              string Name)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // Host in AdHocCommandJobEvent, JobEvent, JobHostSummary
+    // Organization in Application, Credential, ExecutionEnvironment, Inventory, InventorySource, InventoryUpdate,
+    //                 JobTemplate, Job, Label, NotificationTemplate, Project, ProjectUpdate
+    // CredentialType in Credential
+    // ObjectRoles in Credential, InstanceGroup, Inventory, JobTemplate, Project
+    // JobTemplate in Job
+    // NotificationTemplate in Notification
+    public record NameDescriptionSummary(ulong Id,
+                                         string Name,
+                                         string Description)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // Actor in ActivityStream
+    // CreatedBy in AdHocCommand, Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory,
+    //              InventorySource, InventoryUpdate, JobTemplate, Job, Label, NotificationTemplate, Organization,
+    //              Project, Schedule, Team, WorkflowApprovalTemplate, WorkflowJob, WorkflowJobTemplate
+    // ModifiedBy in Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory InventorySource,
+    //               JobTemplate, Label, NotificationTemplate, Organization, Project, Schedule, Team,
+    //               WorkflowApprovalTemplate, WorkflowJob, WorkflowJobTemplate
+    // User in Token
+    // ApprovedOrDeniedBy in WorkflowApproval
     public record UserSummary(ulong Id,
                               string Username,
                               [property: JsonPropertyName("first_name")] string FirstName,
-                              [property: JsonPropertyName("last_name")] string LastName);
+                              [property: JsonPropertyName("last_name")] string LastName)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-
+    // ObjectRoles in Organization
     public record RoleSummary(ulong Id,
                               string Name,
                               string Description,
                               [property: JsonPropertyName("user_only")] bool? UserOnly = null)
-        : NameDescriptionSummary(Id, Name, Description);
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
+    // ExecutionEnvironment in AdHocCommand, InventorySource, InventoryUpdate, JobTemplate, Job, SystemJob
+    // DefaultEnvironment in Organization, Project, ProjectUpdate
+    // ResolvedEnvironment in SystemJobTemplate, WorkflowApprovalTemplate
     public record EnvironmentSummary(ulong Id,
                                      string Name,
                                      string Description,
                                      string Image)
-        : NameDescriptionSummary(Id, Name, Description);
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-    public record RelatedFieldCountsSummary(
-        int Inventories,
-        int Teams,
-        int Users,
-        [property: JsonPropertyName("job_templates")] int JobTemplates,
-        int Admins,
-        int Projects);
+    // RelatedFieldCounts in Organization
+    public record RelatedFieldCountsSummary(int Inventories,
+                                            int Teams,
+                                            int Users,
+                                            [property: JsonPropertyName("job_templates")] int JobTemplates,
+                                            int Admins,
+                                            int Projects)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-    public record TokenSummary(ulong Id, string Token, string Scope);
+    // List<Token> in Application
+    public record TokenSummary(ulong Id,
+                               string Token,
+                               string Scope)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-    public record ListSummary<T>(int Count, T[] Results);
+    public record ListSummary<T>(int Count,
+                                 T[] Results)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
+    // Credential in AdHocCommand, InventorySource, InventoryUpdate, Project, ProjectUpdate
+    // SourceCredential in CredentialInputSource
+    // TargetCredential in CredentialInputSource
     public record CredentialSummary(ulong Id,
                                     string Name,
                                     string Description,
                                     string Kind,
                                     bool Cloud = false,
                                     bool Kubernetes = false,
-                                    [property: JsonPropertyName("credential_type_id")] ulong? CredentialTypeId = null);
+                                    [property: JsonPropertyName("credential_type_id")] ulong? CredentialTypeId = null)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // Credentials in JobTemplate, Job
     public record JobTemplateCredentialSummary(ulong Id,
                                                string Name,
                                                string Description,
                                                string Kind,
-                                               bool Cloud);
+                                               bool Cloud)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
+    // LastJob in InventorySource, JobTemplate, Project, SystemJobTemplate, WorkflowApprovalTemplate, WorkflowJobTemplate
     public record LastJobSummary(ulong Id,
                                  string Name,
                                  string Description,
                                  DateTime? Finished,
                                  JobStatus Status,
-                                 bool Failed);
+                                 bool Failed)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // RecentJobs in Host
     public record HostRecentJobSummary(ulong Id,
                                        string Name,
                                        ResourceType Type,
                                        JobStatus Status,
-                                       DateTime? Finished);
+                                       DateTime? Finished)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // RecentJobs in JobTemplate, WorkflowJobTemplate
     public record RecentJobSummary(ulong Id,
                                    JobStatus Status,
                                    DateTime? Finished,
                                    [property: JsonPropertyName("canceled_on")] DateTime? CanceledOn,
-                                   ResourceType Type);
+                                   ResourceType Type)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // Job in WorkflowJobNode
     public record JobSummary(ulong Id,
                              string Name,
                              string Description,
                              JobStatus Status,
                              bool Failed,
                              double Elapsed,
-                             ResourceType Type);
+                             ResourceType Type)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // LastJob in Host
+    // Job in JobEvent, JobHostSummary
     public record JobExSummary(ulong Id,
                                string Name,
                                string Description,
@@ -93,20 +205,54 @@ namespace AWX.Resources
                                double Elapsed,
                                ResourceType Type,
                                [property: JsonPropertyName("job_template_id")] ulong JobTemplateId,
-                               [property: JsonPropertyName("job_template_name")] string JobTemplateName);
+                               [property: JsonPropertyName("job_template_name")] string JobTemplateName)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-    public record WorkflowJobSummary(ulong Id, string Name, string Description, JobStatus Status, bool Failed, double Elapsed);
+    // SourceWorkflowJob in Job, WorkflowApproval
+    public record WorkflowJobSummary(ulong Id,
+                                     string Name,
+                                     string Description,
+                                     JobStatus Status,
+                                     bool Failed,
+                                     double Elapsed)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-    public record AncestorJobSummary(ulong Id, string Name, ResourceType Type, string Url);
+    // AncestorJob in Job
+    public record AncestorJobSummary(ulong Id,
+                                     string Name,
+                                     ResourceType Type,
+                                     string Url)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-    public record LastJobHostSummary(ulong Id, bool Failed);
+    // LastJobHostSummary in Host
+    public record LastJobHostSummary(ulong Id,
+                                     bool Failed)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
+    // LastUpdate in InventorySource, JobTemplate, Project, SystemJobTemplate, WorkflowApprovalTemplate, WorkflowJobTemplate
     public record LastUpdateSummary(ulong Id,
                                     string Name,
                                     string Description,
                                     JobStatus Status,
                                     bool Failed)
-        : NameDescriptionSummary(Id, Name, Description);
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // Inventory in AdHocCommand, Group, Host, InventorySource, InventoryUpdate, JobTemplate, Job, Schedule, WorkflowJobTemplate
     public record InventorySummary(ulong Id,
                                    string Name,
                                    string Description,
@@ -119,39 +265,104 @@ namespace AWX.Resources
                                    [property: JsonPropertyName("inventory_sources_with_failures")] int InventorySourcesWithFailures,
                                    [property: JsonPropertyName("organization_id")] ulong OrganizationId,
                                    string Kind)
-        : NameDescriptionSummary(Id, Name, Description);
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
+    // InventorySource in InventoryUpdate
     public record InventorySourceSummary(ulong Id,
                                          string Name,
                                          string Source,
                                          [property: JsonPropertyName("last_updated")] DateTime LastUpdated,
-                                         JobStatus Status);
+                                         JobStatus Status)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // SourceProject in InventorySource, InventoryUpdate
+    // Project in JobTemplate, Job, ProjectUpdate
     public record ProjectSummary(ulong Id,
                                  string Name,
                                  string Description,
                                  JobTemplateStatus Status,
                                  [property: JsonPropertyName("scm_type")] string ScmType,
                                  [property: JsonPropertyName("allow_override")] bool AllowOverride)
-        : NameDescriptionSummary(Id, Name, Description);
-    public record ProjectUpdateSummary(ulong Id, string Name, string Description, JobStatus Status, bool Failed)
-        : NameDescriptionSummary(Id, Name, Description);
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
+    // ProjectUpdate in ProjectUpdateJobEvent
+    public record ProjectUpdateSummary(ulong Id,
+                                       string Name,
+                                       string Description,
+                                       JobStatus Status,
+                                       bool Failed)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // UnifiedJobTemplate in InventoryUpdate, Job, ProjectUpdate, Schedule, SystemJob, WorkflowApproval, WorkflowJob,
+    //                       WorkflowJobNode, WorkflowJobTemplateNode
     public record UnifiedJobTemplateSummary(ulong Id,
-                                     string Name,
-                                     string Description,
-                                     [property: JsonPropertyName("unified_job_type")] ResourceType UnifiedJobType)
-        : NameDescriptionSummary(Id, Name, Description);
+                                            string Name,
+                                            string Description,
+                                            [property: JsonPropertyName("unified_job_type")] ResourceType UnifiedJobType)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // InstanceGroup in AdHocCommand, InventoryUpdate, Job, ProjectUpdate, SystemJob
     public record InstanceGroupSummary(ulong Id,
                                        string Name,
-                                       [property: JsonPropertyName("is_container_group")] bool IsContainerGroup);
+                                       [property: JsonPropertyName("is_container_group")] bool IsContainerGroup)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-    public record OwnerSummary(ulong Id, string Type, string Name, string Description, string Url);
+    // Owners in Credential
+    public record OwnerSummary(ulong Id,
+                               string Type,
+                               string Name,
+                               string Description,
+                               string Url)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
+    // Schedule in InventoryUpdate, Job, ProjectUpdate, SystemJob, WorkflowJob
     public record ScheduleSummary(ulong Id,
                                   string Name,
                                   string Description,
-                                  [property: JsonPropertyName("next_run")] DateTime NextRun);
-    public record RecentNotificationSummary(ulong Id, JobStatus Status, DateTime Created, string Error);
+                                  [property: JsonPropertyName("next_run")] DateTime NextRun)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 
-    public record WorkflowApprovalTemplateSummary(ulong Id, string Name, string Description, int Timeout);
+    // RecentNotification in NotificationTemplate
+    public record RecentNotificationSummary(ulong Id,
+                                            JobStatus Status,
+                                            DateTime Created,
+                                            string Error)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
+
+    // WorkflowApprovalTemplate in WorkflowApproval
+    public record WorkflowApprovalTemplateSummary(ulong Id,
+                                                  string Name,
+                                                  string Description,
+                                                  int Timeout)
+        : SummaryBase
+    {
+        public override string ToString() => base.ToString();
+    }
 }

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -220,10 +220,7 @@ namespace AWX.Resources
                                ResourceType Type,
                                [property: JsonPropertyName("job_template_id")] ulong JobTemplateId,
                                [property: JsonPropertyName("job_template_name")] string JobTemplateName)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, Type);
 
     // SourceWorkflowJob in Job, WorkflowApproval
     public record SourceWorkflowJobSummary(ulong Id,
@@ -232,28 +229,19 @@ namespace AWX.Resources
                                            JobStatus Status,
                                            bool Failed,
                                            double Elapsed)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.WorkflowJob);
 
     // AncestorJob in Job
     public record AncestorJobSummary(ulong Id,
                                      string Name,
                                      ResourceType Type,
                                      string Url)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, Type);
 
     // LastJobHostSummary in Host
     public record LastJobHostSummary(ulong Id,
                                      bool Failed)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.JobHostSummary);
 
     // LastUpdate in InventorySource, JobTemplate, Project, SystemJobTemplate, WorkflowApprovalTemplate, WorkflowJobTemplate
     public record LastUpdateSummary(ulong Id,
@@ -279,10 +267,7 @@ namespace AWX.Resources
                                    [property: JsonPropertyName("inventory_sources_with_failures")] int InventorySourcesWithFailures,
                                    [property: JsonPropertyName("organization_id")] ulong OrganizationId,
                                    string Kind)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.Inventory);
 
     // InventorySource in InventoryUpdate
     public record InventorySourceSummary(ulong Id,
@@ -290,10 +275,7 @@ namespace AWX.Resources
                                          string Source,
                                          [property: JsonPropertyName("last_updated")] DateTime LastUpdated,
                                          JobStatus Status)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.InventorySource);
 
     // SourceProject in InventorySource, InventoryUpdate
     // Project in JobTemplate, Job, ProjectUpdate
@@ -303,10 +285,7 @@ namespace AWX.Resources
                                  JobTemplateStatus Status,
                                  [property: JsonPropertyName("scm_type")] string ScmType,
                                  [property: JsonPropertyName("allow_override")] bool AllowOverride)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.Project);
 
     // ProjectUpdate in ProjectUpdateJobEvent
     public record ProjectUpdateSummary(ulong Id,
@@ -314,10 +293,7 @@ namespace AWX.Resources
                                        string Description,
                                        JobStatus Status,
                                        bool Failed)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.ProjectUpdate);
 
     // UnifiedJobTemplate in InventoryUpdate, Job, ProjectUpdate, Schedule, SystemJob, WorkflowApproval, WorkflowJob,
     //                       WorkflowJobNode, WorkflowJobTemplateNode

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -98,20 +98,14 @@ namespace AWX.Resources
                               string Username,
                               [property: JsonPropertyName("first_name")] string FirstName,
                               [property: JsonPropertyName("last_name")] string LastName)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.User);
 
     // ObjectRoles in Organization
-    public record RoleSummary(ulong Id,
-                              string Name,
-                              string Description,
-                              [property: JsonPropertyName("user_only")] bool? UserOnly = null)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+    public record OrganizationObjectRoleSummary(ulong Id,
+                                                string Name,
+                                                string Description,
+                                                [property: JsonPropertyName("user_only")] bool UserOnly = false)
+        : ResourceSummary(Id, ResourceType.Role);
 
     // ExecutionEnvironment in AdHocCommand, InventorySource, InventoryUpdate, JobTemplate, Job, SystemJob
     // DefaultEnvironment in Organization, Project, ProjectUpdate
@@ -120,10 +114,7 @@ namespace AWX.Resources
                                      string Name,
                                      string Description,
                                      string Image)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.ExecutionEnvironment);
 
     // RelatedFieldCounts in Organization
     public record RelatedFieldCountsSummary(int Inventories,
@@ -141,10 +132,7 @@ namespace AWX.Resources
     public record TokenSummary(ulong Id,
                                string Token,
                                string Scope)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.OAuth2AccessToken);
 
     public record ListSummary<T>(int Count,
                                  T[] Results)
@@ -163,10 +151,7 @@ namespace AWX.Resources
                                     bool Cloud = false,
                                     bool Kubernetes = false,
                                     [property: JsonPropertyName("credential_type_id")] ulong? CredentialTypeId = null)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.Credential);
 
     // Credentials in JobTemplate, Job
     public record JobTemplateCredentialSummary(ulong Id,
@@ -174,10 +159,7 @@ namespace AWX.Resources
                                                string Description,
                                                string Kind,
                                                bool Cloud)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, ResourceType.Credential);
 
     // LastJob in InventorySource, JobTemplate, Project, SystemJobTemplate, WorkflowApprovalTemplate, WorkflowJobTemplate
     public record LastJobSummary(ulong Id,
@@ -197,10 +179,7 @@ namespace AWX.Resources
                                        ResourceType Type,
                                        JobStatus Status,
                                        DateTime? Finished)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, Type);
 
     // RecentJobs in JobTemplate, WorkflowJobTemplate
     public record RecentJobSummary(ulong Id,
@@ -208,10 +187,7 @@ namespace AWX.Resources
                                    DateTime? Finished,
                                    [property: JsonPropertyName("canceled_on")] DateTime? CanceledOn,
                                    ResourceType Type)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, Type);
 
     // Job in WorkflowJobNode
     public record JobSummary(ulong Id,
@@ -221,10 +197,7 @@ namespace AWX.Resources
                              bool Failed,
                              double Elapsed,
                              ResourceType Type)
-        : SummaryBase
-    {
-        public override string ToString() => base.ToString();
-    }
+        : ResourceSummary(Id, Type);
 
     // LastJob in Host
     // Job in JobEvent, JobHostSummary

--- a/src/Resources/SummaryField.cs
+++ b/src/Resources/SummaryField.cs
@@ -77,6 +77,14 @@ namespace AWX.Resources
     public record NotificationTemplateSummary(ulong Id, string Name, string Description)
         : ResourceSummary(Id, ResourceType.NotificationTemplate);
 
+    // WorkflowJobTemplate in WorkflowApproval, WorkflowApprovalTemplate, WorkflowJob, WorkflowJobTemplateNode
+    public record WorkflowJobTemplateSummary(ulong Id, string Name, string Description)
+        : ResourceSummary(Id, ResourceType.NotificationTemplate);
+
+    // WorkflowJob in WorkflowApproval, WorkflowJobNode
+    public record WorkflowJobSummary(ulong Id, string Name, string Description)
+        : ResourceSummary(Id, ResourceType.WorkflowJob);
+
     // Actor in ActivityStream
     // CreatedBy in AdHocCommand, Credential, CredentialInputSource, ExecutionEnvironment, Group, Inventory,
     //              InventorySource, InventoryUpdate, JobTemplate, Job, Label, NotificationTemplate, Organization,
@@ -235,12 +243,12 @@ namespace AWX.Resources
     }
 
     // SourceWorkflowJob in Job, WorkflowApproval
-    public record WorkflowJobSummary(ulong Id,
-                                     string Name,
-                                     string Description,
-                                     JobStatus Status,
-                                     bool Failed,
-                                     double Elapsed)
+    public record SourceWorkflowJobSummary(ulong Id,
+                                           string Name,
+                                           string Description,
+                                           JobStatus Status,
+                                           bool Failed,
+                                           double Elapsed)
         : SummaryBase
     {
         public override string ToString() => base.ToString();

--- a/src/Resources/Team.cs
+++ b/src/Resources/Team.cs
@@ -171,7 +171,7 @@ namespace AWX.Resources
             OrganizationSummary Organization,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
-            [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
+            [property: JsonPropertyName("object_roles")] Dictionary<string, ObjectRoleSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities);
 
         public ulong Id { get; } = id;

--- a/src/Resources/Team.cs
+++ b/src/Resources/Team.cs
@@ -168,7 +168,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary Organization,
+            OrganizationSummary Organization,
             [property: JsonPropertyName("created_by")] UserSummary CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
             [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,

--- a/src/Resources/WorkflowApproval.cs
+++ b/src/Resources/WorkflowApproval.cs
@@ -46,14 +46,14 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            [property: JsonPropertyName("workflow_job_template")] NameDescriptionSummary WorkflowJobTemplate,
-            [property: JsonPropertyName("workflow_job")] NameDescriptionSummary WorkflowJob,
+            [property: JsonPropertyName("workflow_job_template")] WorkflowJobTemplateSummary WorkflowJobTemplate,
+            [property: JsonPropertyName("workflow_job")] WorkflowJobSummary WorkflowJob,
             [property: JsonPropertyName("workflow_approval_template")] WorkflowApprovalTemplateSummary WorkflowApprovalTemplate,
             [property: JsonPropertyName("unified_job_template")] UnifiedJobTemplateSummary? UnifiedJobTemplate,
             [property: JsonPropertyName("approved_or_denied_by")] UserSummary? ApprovedOrDeniedBy,
             [property: JsonPropertyName("created_by")] UserSummary? CreatedBy,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
-            [property: JsonPropertyName("source_workflow_job")] WorkflowJobSummary SourceWorkflowJob
+            [property: JsonPropertyName("source_workflow_job")] SourceWorkflowJobSummary SourceWorkflowJob
         );
 
         public RelatedDictionary Related { get; } = related;

--- a/src/Resources/WorkflowApprovalTemplate.cs
+++ b/src/Resources/WorkflowApprovalTemplate.cs
@@ -25,7 +25,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            [property: JsonPropertyName("workflow_job_template")] NameDescriptionSummary WorkflowJobTemplate,
+            [property: JsonPropertyName("workflow_job_template")] WorkflowJobTemplateSummary WorkflowJobTemplate,
             [property: JsonPropertyName("last_job")] LastJobSummary? LastJob,
             [property: JsonPropertyName("last_update")] LastUpdateSummary? LastUpdate,
             [property: JsonPropertyName("created_by")] UserSummary? CreatedBy,

--- a/src/Resources/WorkflowJob.cs
+++ b/src/Resources/WorkflowJob.cs
@@ -112,7 +112,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("created_by")] UserSummary? CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
-            ListSummary<NameSummary> Labels);
+            ListSummary<LabelSummary> Labels);
 
         public RelatedDictionary Related { get; } = related;
         public Summary SummaryFields { get; } = summaryFields;

--- a/src/Resources/WorkflowJob.cs
+++ b/src/Resources/WorkflowJob.cs
@@ -106,6 +106,8 @@ namespace AWX.Resources
         }
 
         public record Summary(
+            OrganizationSummary? Organization,
+            InventorySummary? Inventory,
             [property: JsonPropertyName("workflow_job_template")] WorkflowJobTemplateSummary? WorkflowJobTemplate,
             [property: JsonPropertyName("job_template")] JobTemplateSummary? JobTemplate,
             ScheduleSummary? Schedule,

--- a/src/Resources/WorkflowJob.cs
+++ b/src/Resources/WorkflowJob.cs
@@ -106,7 +106,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            [property: JsonPropertyName("workflow_job_template")] NameDescriptionSummary WorkflowJobTemplate,
+            [property: JsonPropertyName("workflow_job_template")] WorkflowJobTemplateSummary WorkflowJobTemplate,
             ScheduleSummary? Schedule,
             [property: JsonPropertyName("unified_job_template")] UnifiedJobTemplateSummary UnifiedJobTemplate,
             [property: JsonPropertyName("created_by")] UserSummary? CreatedBy,

--- a/src/Resources/WorkflowJob.cs
+++ b/src/Resources/WorkflowJob.cs
@@ -9,7 +9,7 @@ namespace AWX.Resources
         [JsonPropertyName("unified_job_template")]
         ulong UnifiedJobTemplate { get; }
         [JsonPropertyName("workflow_job_template")]
-        ulong WorkflowJobTemplate { get; }
+        ulong? WorkflowJobTemplate { get; }
         [JsonPropertyName("extra_vars")]
         string ExtraVars { get; }
         [JsonPropertyName("allow_simultaneous")]
@@ -46,7 +46,7 @@ namespace AWX.Resources
                              string description, ulong unifiedJobTemplate, JobLaunchType launchType, JobStatus status,
                              ulong? executionEnvironment, bool failed, DateTime? started, DateTime? finished,
                              DateTime? canceledOn, double elapsed, string jobExplanation, LaunchedBy launchedBy,
-                             string? workUnitId, ulong workflowJobTemplate, string extraVars, bool allowSimultaneous,
+                             string? workUnitId, ulong? workflowJobTemplate, string extraVars, bool allowSimultaneous,
                              ulong? jobTemplate, bool isSlicedJob, ulong? inventory, string? limit, string? scmBranch,
                              string webhookService, ulong? webhookCredential, string webhookGuid, string? skipTags,
                              string? jobTags)
@@ -106,7 +106,8 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            [property: JsonPropertyName("workflow_job_template")] WorkflowJobTemplateSummary WorkflowJobTemplate,
+            [property: JsonPropertyName("workflow_job_template")] WorkflowJobTemplateSummary? WorkflowJobTemplate,
+            [property: JsonPropertyName("job_template")] JobTemplateSummary? JobTemplate,
             ScheduleSummary? Schedule,
             [property: JsonPropertyName("unified_job_template")] UnifiedJobTemplateSummary UnifiedJobTemplate,
             [property: JsonPropertyName("created_by")] UserSummary? CreatedBy,
@@ -118,7 +119,7 @@ namespace AWX.Resources
         public Summary SummaryFields { get; } = summaryFields;
         public string Description { get; } = description;
         public ulong UnifiedJobTemplate { get; } = unifiedJobTemplate;
-        public ulong WorkflowJobTemplate { get; } = workflowJobTemplate;
+        public ulong? WorkflowJobTemplate { get; } = workflowJobTemplate;
         public string ExtraVars { get; } = extraVars;
         public bool AllowSimultaneous { get; } = allowSimultaneous;
         public ulong? JobTemplate { get; } = jobTemplate;
@@ -138,7 +139,7 @@ namespace AWX.Resources
                             ulong? executionEnvironment, bool failed, DateTime? started, DateTime? finished,
                             DateTime? canceledOn, double elapsed, string jobArgs, string jobCwd,
                             Dictionary<string, string> jobEnv, string jobExplanation, string resultTraceback,
-                            LaunchedBy launchedBy, string? workUnitId, ulong workflowJobTemplate, string extraVars,
+                            LaunchedBy launchedBy, string? workUnitId, ulong? workflowJobTemplate, string extraVars,
                             bool allowSimultaneous, ulong? jobTemplate, bool isSlicedJob, ulong? inventory,
                             string? limit, string? scmBranch, string webhookService, ulong? webhookCredential,
                             string webhookGuid, string? skipTags, string? jobTags)
@@ -162,7 +163,7 @@ namespace AWX.Resources
                                   DateTime? finished, DateTime? canceledOn, double elapsed, string jobArgs,
                                   string jobCwd, Dictionary<string, string> jobEnv, string jobExplanation,
                                   string resultTraceback, LaunchedBy launchedBy, string? workUnitId,
-                                  ulong workflowJobTemplate, string extraVars, bool allowSimultaneous,
+                                  ulong? workflowJobTemplate, string extraVars, bool allowSimultaneous,
                                   ulong? jobTemplate, bool isSlicedJob, ulong? inventory, string? limit,
                                   string? scmBranch, string webhookService, ulong? webhookCredential, string webhookGuid,
                                   string? skipTags, string? jobTags)

--- a/src/Resources/WorkflowJobNode.cs
+++ b/src/Resources/WorkflowJobNode.cs
@@ -120,7 +120,7 @@ namespace AWX.Resources
         }
         public record Summary(
             JobSummary? Job,
-            [property: JsonPropertyName("workflow_job")] NameDescriptionSummary WorkflowJob,
+            [property: JsonPropertyName("workflow_job")] WorkflowJobSummary WorkflowJob,
             [property: JsonPropertyName("unified_job_template")] UnifiedJobTemplateSummary UnifiedJobTemplate);
 
         public ulong Id { get; } = id;

--- a/src/Resources/WorkflowJobNode.cs
+++ b/src/Resources/WorkflowJobNode.cs
@@ -36,7 +36,7 @@ namespace AWX.Resources
         [JsonPropertyName("workflow_job")]
         ulong WorkflowJob { get; }
         [JsonPropertyName("unified_job_template")]
-        ulong UnifiedJobTemplate { get; }
+        ulong? UnifiedJobTemplate { get; }
         [JsonPropertyName("success_nodes")]
         ulong[] SuccessNodes { get; }
         [JsonPropertyName("failure_nodes")]
@@ -80,7 +80,7 @@ namespace AWX.Resources
                                  int? timeout,
                                  ulong? job,
                                  ulong workflowJob,
-                                 ulong unifiedJobTemplate,
+                                 ulong? unifiedJobTemplate,
                                  ulong[] successNodes,
                                  ulong[] failureNodes,
                                  ulong[] alwaysNodes,
@@ -121,7 +121,7 @@ namespace AWX.Resources
         public record Summary(
             JobSummary? Job,
             [property: JsonPropertyName("workflow_job")] WorkflowJobSummary WorkflowJob,
-            [property: JsonPropertyName("unified_job_template")] UnifiedJobTemplateSummary UnifiedJobTemplate);
+            [property: JsonPropertyName("unified_job_template")] UnifiedJobTemplateSummary? UnifiedJobTemplate);
 
         public ulong Id { get; } = id;
         public ResourceType Type { get; } = type;
@@ -146,7 +146,7 @@ namespace AWX.Resources
         public int? Timeout { get; } = timeout;
         public ulong? Job { get; } = job;
         public ulong WorkflowJob { get; } = workflowJob;
-        public ulong UnifiedJobTemplate { get; } = unifiedJobTemplate;
+        public ulong? UnifiedJobTemplate { get; } = unifiedJobTemplate;
         public ulong[] SuccessNodes { get; } = successNodes;
         public ulong[] FailureNodes { get; } = failureNodes;
         public ulong[] AlwaysNodes { get; } = alwaysNodes;

--- a/src/Resources/WorkflowJobTemplate.cs
+++ b/src/Resources/WorkflowJobTemplate.cs
@@ -125,7 +125,7 @@ namespace AWX.Resources
         }
 
         public record Summary(
-            NameDescriptionSummary? Organization,
+            OrganizationSummary? Organization,
             InventorySummary? Inventory,
             [property: JsonPropertyName("last_job")] LastJobSummary? LastJob,
             [property: JsonPropertyName("last_update")] LastUpdateSummary? LastUpdate,

--- a/src/Resources/WorkflowJobTemplate.cs
+++ b/src/Resources/WorkflowJobTemplate.cs
@@ -133,7 +133,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
             [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
-            ListSummary<NameSummary> Labels,
+            ListSummary<LabelSummary> Labels,
             [property: JsonPropertyName("recent_jobs")] RecentJobSummary[] RecentJobs);
 
 

--- a/src/Resources/WorkflowJobTemplate.cs
+++ b/src/Resources/WorkflowJobTemplate.cs
@@ -131,7 +131,7 @@ namespace AWX.Resources
             [property: JsonPropertyName("last_update")] LastUpdateSummary? LastUpdate,
             [property: JsonPropertyName("created_by")] UserSummary? CreatedBy,
             [property: JsonPropertyName("modified_by")] UserSummary? ModifiedBy,
-            [property: JsonPropertyName("object_roles")] Dictionary<string, NameDescriptionSummary> ObjectRoles,
+            [property: JsonPropertyName("object_roles")] Dictionary<string, ObjectRoleSummary> ObjectRoles,
             [property: JsonPropertyName("user_capabilities")] Capability UserCapabilities,
             ListSummary<LabelSummary> Labels,
             [property: JsonPropertyName("recent_jobs")] RecentJobSummary[] RecentJobs);

--- a/src/Resources/WorkflowJobTemplateNode.cs
+++ b/src/Resources/WorkflowJobTemplateNode.cs
@@ -101,7 +101,7 @@ namespace AWX.Resources
             }
         }
         public record Summary(
-            [property: JsonPropertyName("workflow_job_template")] NameDescriptionSummary WorkflowJobTemplate,
+            [property: JsonPropertyName("workflow_job_template")] WorkflowJobTemplateSummary WorkflowJobTemplate,
             [property: JsonPropertyName("unified_job_template")] UnifiedJobTemplateSummary UnifiedJobTemplate);
 
         public ulong Id { get; } = id;


### PR DESCRIPTION
Fix `SummaryFields` for each AWX/AnsibleTower resource to hav `Id` and `Type` properties as far as possible.
Because, want to pipeline input to `Find-***` cmdlet using the value in the `SummaryFields`.

Also bug fixies are included during the modification.
