### PR TITLE
Improve `Get-*` cmdlet to enable to accept get Id values from pipeline input

### DIFF
--- a/docs/en-US/cmdlets/Get-ActivityStream.md
+++ b/docs/en-US/cmdlets/Get-ActivityStream.md
@@ -51,7 +51,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-AdHocCommandJob.md
+++ b/docs/en-US/cmdlets/Get-AdHocCommandJob.md
@@ -51,7 +51,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Application.md
+++ b/docs/en-US/cmdlets/Get-Application.md
@@ -43,7 +43,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Credential.md
+++ b/docs/en-US/cmdlets/Get-Credential.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-CredentialInputSource.md
+++ b/docs/en-US/cmdlets/Get-CredentialInputSource.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-CredentialType.md
+++ b/docs/en-US/cmdlets/Get-CredentialType.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-ExecutionEnvironment.md
+++ b/docs/en-US/cmdlets/Get-ExecutionEnvironment.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Group.md
+++ b/docs/en-US/cmdlets/Get-Group.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Host.md
+++ b/docs/en-US/cmdlets/Get-Host.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-HostMetric.md
+++ b/docs/en-US/cmdlets/Get-HostMetric.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Instance.md
+++ b/docs/en-US/cmdlets/Get-Instance.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-InstanceGroup.md
+++ b/docs/en-US/cmdlets/Get-InstanceGroup.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Inventory.md
+++ b/docs/en-US/cmdlets/Get-Inventory.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-InventorySource.md
+++ b/docs/en-US/cmdlets/Get-InventorySource.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-InventoryUpdateJob.md
+++ b/docs/en-US/cmdlets/Get-InventoryUpdateJob.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Job.md
+++ b/docs/en-US/cmdlets/Get-Job.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-JobHostSummary.md
+++ b/docs/en-US/cmdlets/Get-JobHostSummary.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-JobTemplate.md
+++ b/docs/en-US/cmdlets/Get-JobTemplate.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Label.md
+++ b/docs/en-US/cmdlets/Get-Label.md
@@ -44,7 +44,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Notification.md
+++ b/docs/en-US/cmdlets/Get-Notification.md
@@ -59,7 +59,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-NotificationTemplate.md
+++ b/docs/en-US/cmdlets/Get-NotificationTemplate.md
@@ -61,7 +61,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Organization.md
+++ b/docs/en-US/cmdlets/Get-Organization.md
@@ -60,7 +60,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Project.md
+++ b/docs/en-US/cmdlets/Get-Project.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-ProjectUpdateJob.md
+++ b/docs/en-US/cmdlets/Get-ProjectUpdateJob.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Role.md
+++ b/docs/en-US/cmdlets/Get-Role.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Schedule.md
+++ b/docs/en-US/cmdlets/Get-Schedule.md
@@ -74,7 +74,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-SystemJob.md
+++ b/docs/en-US/cmdlets/Get-SystemJob.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-SystemJobTemplate.md
+++ b/docs/en-US/cmdlets/Get-SystemJobTemplate.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Team.md
+++ b/docs/en-US/cmdlets/Get-Team.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-Token.md
+++ b/docs/en-US/cmdlets/Get-Token.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-User.md
+++ b/docs/en-US/cmdlets/Get-User.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-WorkflowApprovalRequest.md
+++ b/docs/en-US/cmdlets/Get-WorkflowApprovalRequest.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-WorkflowApprovalTemplate.md
+++ b/docs/en-US/cmdlets/Get-WorkflowApprovalTemplate.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-WorkflowJob.md
+++ b/docs/en-US/cmdlets/Get-WorkflowJob.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-WorkflowJobNode.md
+++ b/docs/en-US/cmdlets/Get-WorkflowJobNode.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-WorkflowJobTemplate.md
+++ b/docs/en-US/cmdlets/Get-WorkflowJobTemplate.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/cmdlets/Get-WorkflowJobTemplateNode.md
+++ b/docs/en-US/cmdlets/Get-WorkflowJobTemplateNode.md
@@ -48,7 +48,7 @@ Aliases:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: True (ByValue)
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/src/Cmdlets/APIBase.cs
+++ b/src/Cmdlets/APIBase.cs
@@ -99,9 +99,16 @@ namespace AWX.Cmdlets
 
     public abstract class GetCmdletBase : APICmdletBase
     {
-        [Parameter(Mandatory = true, Position = 0, ValueFromRemainingArguments = true, ValueFromPipeline = true)]
+        [Parameter(Mandatory = true,
+                   Position = 0,
+                   ValueFromRemainingArguments = true,
+                   ValueFromPipeline = true,
+                   ValueFromPipelineByPropertyName = true)]
         [PSDefaultValue(Value = 1, Help = "The resource ID")]
         public ulong[] Id { get; set; } = [];
+
+        [Parameter(ValueFromPipelineByPropertyName = true, DontShow = true)]
+        public ResourceType? Type { get; set; }
 
         protected readonly HashSet<ulong> IdSet  = [];
         protected readonly NameValueCollection Query = HttpUtility.ParseQueryString("");

--- a/src/Cmdlets/ActivityStreamCommand.cs
+++ b/src/Cmdlets/ActivityStreamCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.ActivityStream)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/AdHocCommandCommand.cs
+++ b/src/Cmdlets/AdHocCommandCommand.cs
@@ -11,6 +11,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.AdHocCommand)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/ApplicationCommand.cs
+++ b/src/Cmdlets/ApplicationCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.OAuth2Application)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/CredentialCommand.cs
+++ b/src/Cmdlets/CredentialCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Credential)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/CredentialInputSourceCommand.cs
+++ b/src/Cmdlets/CredentialInputSourceCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.CredentialInputSource)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/CredentialTypeCommand.cs
+++ b/src/Cmdlets/CredentialTypeCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.CredentialType)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/ExecutionEnvironmentCommand.cs
+++ b/src/Cmdlets/ExecutionEnvironmentCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.ExecutionEnvironment)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/GroupCommand.cs
+++ b/src/Cmdlets/GroupCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Group)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/HostCommand.cs
+++ b/src/Cmdlets/HostCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Host)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/HostMetricsCommand.cs
+++ b/src/Cmdlets/HostMetricsCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.HostMetrics)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/InstanceCommand.cs
+++ b/src/Cmdlets/InstanceCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Instance)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/InstanceGroupCommand.cs
+++ b/src/Cmdlets/InstanceGroupCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.InstanceGroup)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/InventoryCommand.cs
+++ b/src/Cmdlets/InventoryCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Inventory)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/InventorySourceCommand.cs
+++ b/src/Cmdlets/InventorySourceCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.InventorySource)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/InventoryUpdateCommand.cs
+++ b/src/Cmdlets/InventoryUpdateCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.InventoryUpdate)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/JobCommand.cs
+++ b/src/Cmdlets/JobCommand.cs
@@ -10,6 +10,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Job)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/JobHostSummaryCommand.cs
+++ b/src/Cmdlets/JobHostSummaryCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.JobHostSummary)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -12,6 +12,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.JobTemplate)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/LabelCommand.cs
+++ b/src/Cmdlets/LabelCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Label)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/NotificationCommand.cs
+++ b/src/Cmdlets/NotificationCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Notification)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/NotificationTemplateCommand.cs
+++ b/src/Cmdlets/NotificationTemplateCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.NotificationTemplate)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/OrganizationCommand.cs
+++ b/src/Cmdlets/OrganizationCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Organization)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/ProjectCommand.cs
+++ b/src/Cmdlets/ProjectCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Project)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/ProjectUpdateCommand.cs
+++ b/src/Cmdlets/ProjectUpdateCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.ProjectUpdate)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/RoleCommand.cs
+++ b/src/Cmdlets/RoleCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Role)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/ScheduleCommand.cs
+++ b/src/Cmdlets/ScheduleCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Schedule)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/SystemJobCommand.cs
+++ b/src/Cmdlets/SystemJobCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.SystemJob)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/SystemJobTemplateCommand.cs
+++ b/src/Cmdlets/SystemJobTemplateCommand.cs
@@ -11,6 +11,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.SystemJobTemplate)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/TeamCommand.cs
+++ b/src/Cmdlets/TeamCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.Team)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/TokenCommand.cs
+++ b/src/Cmdlets/TokenCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.OAuth2AccessToken)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/UserCommand.cs
+++ b/src/Cmdlets/UserCommand.cs
@@ -23,6 +23,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.User)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/WorkflowApprovalCommand.cs
+++ b/src/Cmdlets/WorkflowApprovalCommand.cs
@@ -10,6 +10,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.WorkflowApproval)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/WorkflowApprovalTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowApprovalTemplateCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.WorkflowApprovalTemplate)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/WorkflowJobCommand.cs
+++ b/src/Cmdlets/WorkflowJobCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.WorkflowJob)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 if (!IdSet.Add(id))

--- a/src/Cmdlets/WorkflowJobNodeCommand.cs
+++ b/src/Cmdlets/WorkflowJobNodeCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.WorkflowJobNode)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -12,6 +12,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.WorkflowJobTemplate)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Cmdlets/WorkflowJobTemplateNodeCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateNodeCommand.cs
@@ -9,6 +9,10 @@ namespace AWX.Cmdlets
     {
         protected override void ProcessRecord()
         {
+            if (Type != null && Type != ResourceType.WorkflowJobTemplateNode)
+            {
+                return;
+            }
             foreach (var id in Id)
             {
                 IdSet.Add(id);

--- a/src/Resources/HostMetrics.cs
+++ b/src/Resources/HostMetrics.cs
@@ -9,6 +9,7 @@ namespace AWX.Resources
         public const string PATH = "/api/v2/host_metrics/";
 
         public ulong Id { get; } = id;
+        public ResourceType Type { get; } = ResourceType.HostMetrics;
         public string Hostname { get; } = hostname;
         public string Url { get; } = url;
         [JsonPropertyName("first_automation")]


### PR DESCRIPTION
To accept pipeline input from objects with `Id` property.

And for validating `Id` value is the specific resource type, accept `Type` property too.