### PR TITLE
Show information needed to start on launch

### DIFF
--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -195,7 +195,8 @@ namespace AWX.Cmdlets
         {
             var jt = requirements.JobTemplateData;
             var def = requirements.Defaults;
-            var (fixedColor, implicitColor, explicitColor) = ((ConsoleColor?)null, ConsoleColor.Magenta, ConsoleColor.Green);
+            var (fixedColor, implicitColor, explicitColor, requiredColor) =
+                ((ConsoleColor?)null, ConsoleColor.Magenta, ConsoleColor.Green, ConsoleColor.Red);
             WriteHost($"[{jt.Id}] {jt.Name} - {jt.Description}\n");
             var fmt = "{0,22} : {1}\n";
             {
@@ -261,6 +262,15 @@ namespace AWX.Cmdlets
                 WriteHost(sb.ToString(),
                             foregroundColor: requirements.AskVariablesOnLaunch ? (ExtraVars == null ? implicitColor : explicitColor) : fixedColor);
             }
+            if (requirements.SurveyEnabled)
+            {
+                WriteHost(string.Format(fmt, "Survey", "Enabled"), foregroundColor: requiredColor);
+            }
+            if (requirements.VariablesNeededToStart.Length > 0)
+            {
+                WriteHost(string.Format(fmt, "Variables", $"[{string.Join(", ", requirements.VariablesNeededToStart)}]"),
+                            foregroundColor: requiredColor);
+            }
             {
                 var diffModeVal = $"{def.DiffMode}"
                                   + (requirements.AskDiffModeOnLaunch && DiffMode != null ? $" => {DiffMode}" : "");
@@ -285,6 +295,11 @@ namespace AWX.Cmdlets
                         + (requirements.AskCredentialOnLaunch && Credentials != null ? $" => {string.Join(',', Credentials.Select(id => $"[{id}]"))}" : "");
                 WriteHost(string.Format(fmt, "Credentials", credentialsVal),
                             foregroundColor: requirements.AskCredentialOnLaunch ? (Credentials == null ? implicitColor : explicitColor) : fixedColor);
+            }
+            if (requirements.PasswordsNeededToStart.Length > 0)
+            {
+                WriteHost(string.Format(fmt, "CredentialPassswords", $"[{string.Join(", ", requirements.PasswordsNeededToStart)}]"),
+                            foregroundColor: requiredColor);
             }
             if (def.ExecutionEnvironment.Id != null || ExecutionEnvironment != null)
             {

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -223,6 +223,15 @@ namespace AWX.Cmdlets
                 return null;
             }
             ShowJobTemplateInfo(requirements);
+            if (requirements.NodeTemplatesMissing.Length > 0)
+            {
+                var missingNodes = string.Join(", ", requirements.NodeTemplatesMissing);
+                WriteError(new ErrorRecord(new InvalidOperationException($"Missing Templates in Nodes: [{missingNodes}]"),
+                                           "MissingNodeTemplates",
+                                           ErrorCategory.ResourceUnavailable,
+                                           requirements));
+                return null;
+            }
             var sendData = CreateSendData();
             var apiResult = CreateResource<WorkflowJob.LaunchResult>($"{WorkflowJobTemplate.PATH}{id}/launch/", sendData);
             var launchResult = apiResult.Contents;

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -132,7 +132,8 @@ namespace AWX.Cmdlets
         {
             var wjt = requirements.WorkflowJobTemplateData;
             var def = requirements.Defaults;
-            var (fixedColor, implicitColor, explicitColor) = ((ConsoleColor?)null, ConsoleColor.Magenta, ConsoleColor.Green);
+            var (fixedColor, implicitColor, explicitColor, requiredColor) =
+                ((ConsoleColor?)null, ConsoleColor.Magenta, ConsoleColor.Green, ConsoleColor.Red);
             WriteHost($"[{wjt.Id}] {wjt.Name} - {wjt.Description}\n");
             var fmt = "{0,22} : {1}\n";
             if (def.Inventory.Id != null || Inventory != null)
@@ -198,6 +199,20 @@ namespace AWX.Cmdlets
                 }
                 WriteHost(sb.ToString(),
                             foregroundColor: requirements.AskVariablesOnLaunch ? (ExtraVars == null ? implicitColor : explicitColor) : fixedColor);
+            }
+            if (requirements.SurveyEnabled)
+            {
+                WriteHost(string.Format(fmt, "Survey", "Enabled"), foregroundColor: requiredColor);
+            }
+            if (requirements.VariablesNeededToStart.Length > 0)
+            {
+                WriteHost(string.Format(fmt, "Variables", $"[{string.Join(", ", requirements.VariablesNeededToStart)}]"),
+                            foregroundColor: requiredColor);
+            }
+            if (requirements.NodePromptsRejected.Length > 0)
+            {
+                WriteWarning("Prompt Input will be ignored in following nodes: " +
+                        $"[{string.Join(", ", requirements.NodePromptsRejected)}]");
             }
         }
         protected WorkflowJob.LaunchResult? Launch(ulong id)

--- a/src/Resources/WorkflowJobTemplateLaunch.cs
+++ b/src/Resources/WorkflowJobTemplateLaunch.cs
@@ -7,7 +7,7 @@ namespace AWX.Resources
                                                        bool askVariablesOnLaunch, bool askLabelsOnLaunch,
                                                        bool askTagsOnLaunch, bool askSkipTagsOnLaunch,
                                                        bool surveyEnabled, string[] variablesNeededToStart,
-                                                       string[] nodeTemplatesMissing, ulong[] nodePromptsRejected,
+                                                       ulong[] nodeTemplatesMissing, ulong[] nodePromptsRejected,
                                                        TemplateData workflowJobTemplateData,
                                                        WorkflowJobTemplateDefaults defaults)
     {
@@ -33,7 +33,7 @@ namespace AWX.Resources
         public string[] VariablesNeededToStart { get; } = variablesNeededToStart;
 
         [JsonPropertyName("node_templates_missing")]
-        public string[] NodeTemplatesMissing { get; } = nodeTemplatesMissing;
+        public ulong[] NodeTemplatesMissing { get; } = nodeTemplatesMissing;
         [JsonPropertyName("node_prompts_rejected")]
         public ulong[] NodePromptsRejected { get; } = nodePromptsRejected;
 


### PR DESCRIPTION
## JobTemplate
- Show when `SurveyEnabled`
- Show when `VariablesNeededToStart`
- Show when `PasswordsNeededToStart`

## WorkflowJobTemplate
- Show when `SurveyEnabled`
- Show when `VariablesNeededToStart`
- ⚠️  Show warnings when `NodePromptsRejected`
- 🛑 Don't start when `NodeTemplatesMissing`
