### PR TITLE
:bug: use `/api/v2/{path}/{id}/` API path when the IDs count is only one

### DIFF
--- a/src/Cmdlets/ActivityStreamCommand.cs
+++ b/src/Cmdlets/ActivityStreamCommand.cs
@@ -20,11 +20,19 @@ namespace AWX.Cmdlets
         }
         protected override void EndProcessing()
         {
-            Query.Add("id__in", string.Join(',', IdSet));
-            Query.Add("page_size", $"{IdSet.Count}");
-            foreach (var resultSet in GetResultSet<ActivityStream>($"{ActivityStream.PATH}?{Query}", true))
+            if (IdSet.Count == 1)
             {
-                WriteObject(resultSet.Results, true);
+                var res = GetResource<ActivityStream>($"{ActivityStream.PATH}{IdSet.First()}/");
+                WriteObject(res);
+            }
+            else
+            {
+                Query.Add("id__in", string.Join(',', IdSet));
+                Query.Add("page_size", $"{IdSet.Count}");
+                foreach (var resultSet in GetResultSet<ActivityStream>(ActivityStream.PATH, Query, true))
+                {
+                    WriteObject(resultSet.Results, true);
+                }
             }
         }
     }

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -22,11 +22,19 @@ namespace AWX.Cmdlets
         }
         protected override void EndProcessing()
         {
-            Query.Add("id__in", string.Join(',', IdSet));
-            Query.Add("page_size", $"{IdSet.Count}");
-            foreach (var resultSet in GetResultSet<JobTemplate>($"{JobTemplate.PATH}?{Query}", true))
+            if (IdSet.Count == 1)
             {
-                WriteObject(resultSet.Results, true);
+                var result = GetResource<JobTemplate>($"{JobTemplate.PATH}{IdSet.First()}/");
+                WriteObject(result);
+            }
+            else
+            {
+                Query.Add("id__in", string.Join(',', IdSet));
+                Query.Add("page_size", $"{IdSet.Count}");
+                foreach (var resultSet in GetResultSet<JobTemplate>(JobTemplate.PATH, Query, true))
+                {
+                    WriteObject(resultSet.Results, true);
+                }
             }
         }
     }

--- a/src/Cmdlets/SystemJobTemplateCommand.cs
+++ b/src/Cmdlets/SystemJobTemplateCommand.cs
@@ -22,11 +22,19 @@ namespace AWX.Cmdlets
         }
         protected override void EndProcessing()
         {
-            Query.Add("id__in", string.Join(',', IdSet));
-            Query.Add("page_size", $"{IdSet.Count}");
-            foreach (var resultSet in GetResultSet<SystemJobTemplate>($"{SystemJobTemplate.PATH}?{Query}", true))
+            if (IdSet.Count == 1)
             {
-                WriteObject(resultSet.Results, true);
+                var res = GetResource<SystemJobTemplate>($"{SystemJobTemplate.PATH}{IdSet.First()}/");
+                WriteObject(res);
+            }
+            else
+            {
+                Query.Add("id__in", string.Join(',', IdSet));
+                Query.Add("page_size", $"{IdSet.Count}");
+                foreach (var resultSet in GetResultSet<SystemJobTemplate>(SystemJobTemplate.PATH, Query, true))
+                {
+                    WriteObject(resultSet.Results, true);
+                }
             }
         }
     }

--- a/src/Cmdlets/WorkflowJobNodeCommand.cs
+++ b/src/Cmdlets/WorkflowJobNodeCommand.cs
@@ -20,11 +20,19 @@ namespace AWX.Cmdlets
         }
         protected override void EndProcessing()
         {
-            Query.Add("id__in", string.Join(',', IdSet));
-            Query.Add("page_size", $"{IdSet.Count}");
-            foreach (var resultSet in GetResultSet<WorkflowJobNode>($"{WorkflowJobNode.PATH}?{Query}", true))
+            if (IdSet.Count == 1)
             {
-                WriteObject(resultSet.Results, true);
+                var res = GetResource<WorkflowJobNode>($"{WorkflowJobNode.PATH}{IdSet.First()}/");
+                WriteObject(res);
+            }
+            else
+            {
+                Query.Add("id__in", string.Join(',', IdSet));
+                Query.Add("page_size", $"{IdSet.Count}");
+                foreach (var resultSet in GetResultSet<WorkflowJobNode>(WorkflowJobNode.PATH, Query, true))
+                {
+                    WriteObject(resultSet.Results, true);
+                }
             }
         }
     }

--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -22,11 +22,19 @@ namespace AWX.Cmdlets
         }
         protected override void EndProcessing()
         {
-            Query.Add("id__in", string.Join(',', IdSet));
-            Query.Add("page_size", $"{IdSet.Count}");
-            foreach (var resultSet in GetResultSet<WorkflowJobTemplate>($"{WorkflowJobTemplate.PATH}?{Query}", true))
+            if (IdSet.Count == 1)
             {
-                WriteObject(resultSet.Results, true);
+                var res = GetResource<WorkflowJobTemplate>($"{WorkflowJobTemplate.PATH}{IdSet.First()}/");
+                WriteObject(res);
+            }
+            else
+            {
+                Query.Add("id__in", string.Join(',', IdSet));
+                Query.Add("page_size", $"{IdSet.Count}");
+                foreach (var resultSet in GetResultSet<WorkflowJobTemplate>(WorkflowJobTemplate.PATH, Query, true))
+                {
+                    WriteObject(resultSet.Results, true);
+                }
             }
         }
     }

--- a/src/Cmdlets/WorkflowJobTemplateNodeCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateNodeCommand.cs
@@ -20,11 +20,22 @@ namespace AWX.Cmdlets
         }
         protected override void EndProcessing()
         {
-            Query.Add("id__in", string.Join(',', IdSet));
-            Query.Add("page_size", $"{IdSet.Count}");
-            foreach (var resultSet in GetResultSet<WorkflowJobTemplateNode>($"{WorkflowJobTemplateNode.PATH}?{Query}", true))
+            string path;
+            if (IdSet.Count == 1)
             {
-                WriteObject(resultSet.Results, true);
+                path = $"{WorkflowJobTemplateNode.PATH}{IdSet.First()}/";
+                var res = GetResource<WorkflowJobTemplateNode>(path);
+                WriteObject(res);
+            }
+            else
+            {
+                path = WorkflowJobTemplateNode.PATH;
+                Query.Add("id__in", string.Join(',', IdSet));
+                Query.Add("page_size", $"{IdSet.Count}");
+                foreach (var resultSet in GetResultSet<WorkflowJobTemplateNode>(path, Query, true))
+                {
+                    WriteObject(resultSet.Results, true);
+                }
             }
         }
     }


### PR DESCRIPTION
use `/api/v2/{path}/{id}/` API path when the IDs count is only one

- [x] `Get-WorkflowJobTemplateNode`
- [x] `Get-ActivityStream`
- [x] `Get-JobTemplate`
- [x] `Get-SystemJobTemplate`
- [x] `Get-WorkflowJobNode`
- [x] `Get-WorkflowJobTemplate`