### PR TITLE
:sparkles: Implement `Interactive` mode on JobTemplate launcher

### DIFF
--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -519,8 +519,9 @@ namespace AWX.Cmdlets
                     WriteHost(string.Format(skipFormat, "Credentials", strData), dontshow: true);
                 }
                 else if (prompt.AskList<ulong>("Credentials",
-                            requirements.Defaults.Credentials?.Select(x => $"[{x.Id}] {x.Name}"),
-                            "", out var credentialsAnswer))
+                                               defaultValues: requirements.Defaults.Credentials?.Select(x => $"[{x.Id}] {x.Name}"),
+                                               helpMessage: "",
+                                               out var credentialsAnswer))
                 {
                     if (!credentialsAnswer.IsEmpty)
                         sendData[key] = credentialsAnswer.Input;
@@ -566,12 +567,15 @@ namespace AWX.Cmdlets
                     WriteHost(string.Format(skipFormat, "Job Type", sendData[key]), dontshow: true);
                 }
                 else if (prompt.AskBool("Job Type",
-                                        requirements.Defaults.JobType == Resources.JobType.Run,
-                                        "Run", "Check", out var jobTypeAnswer))
+                                        defaultValue: requirements.Defaults.JobType == Resources.JobType.Run,
+                                        trueHelpMessage: "Run",
+                                        falseHelpMessage: "Check",
+                                        out var jobTypeAnswer))
                 {
                     if (!jobTypeAnswer.IsEmpty)
                         sendData[key] = (jobTypeAnswer.Input ? Resources.JobType.Run : Resources.JobType.Check)
-                            .ToString().ToLowerInvariant();
+                                        .ToString()
+                                        .ToLowerInvariant();
                 }
                 else { return false; }
             }
@@ -584,8 +588,10 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "ScmBranch", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("ScmBranch", requirements.Defaults.ScmBranch,
-                                    "", out var branchAnswer))
+                else if (prompt.Ask("ScmBranch",
+                                    defaultValue: requirements.Defaults.ScmBranch,
+                                    helpMessage: "",
+                                    out var branchAnswer))
                 {
                     if (!branchAnswer.IsEmpty)
                         sendData[key] = branchAnswer.Input;
@@ -603,8 +609,9 @@ namespace AWX.Cmdlets
                     WriteHost(string.Format(skipFormat, "Labels", strData), dontshow: true);
                 }
                 else if (prompt.AskList<ulong>("Labels",
-                                               requirements.Defaults.Labels?.Select(x => $"[{x.Id}] {x.Name}") ?? [],
-                                               "", out var labelsAnswer))
+                                               defaultValues: requirements.Defaults.Labels?.Select(x => $"[{x.Id}] {x.Name}") ?? [],
+                                               helpMessage: "",
+                                               out var labelsAnswer))
                 {
                     if (!labelsAnswer.IsEmpty)
                         sendData[key] = labelsAnswer.Input;
@@ -640,8 +647,10 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Limit", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("Limit", requirements.Defaults.Limit,
-                                    "", out var limitAnswer))
+                else if (prompt.Ask("Limit",
+                                    defaultValue: requirements.Defaults.Limit,
+                                    helpMessage: "",
+                                    out var limitAnswer))
                 {
                     if (!limitAnswer.IsEmpty)
                         sendData[key] = limitAnswer.Input;
@@ -658,8 +667,10 @@ namespace AWX.Cmdlets
                     var v = (JobVerbosity)((int)(sendData[key] ?? 0));
                     WriteHost(string.Format(skipFormat, "Job Tags", $"{v:d} ({v:g})"), dontshow: true);
                 }
-                else if (prompt.AskEnum<JobVerbosity>("Verbosity", requirements.Defaults.Verbosity,
-                                                      "", out var verbosityAnswer))
+                else if (prompt.AskEnum<JobVerbosity>("Verbosity",
+                                                      defaultValue: requirements.Defaults.Verbosity,
+                                                      helpMessage: "",
+                                                      out var verbosityAnswer))
                 {
                     if (!verbosityAnswer.IsEmpty)
                         sendData[key] = (int)verbosityAnswer.Input;
@@ -715,8 +726,11 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Diff Mode", sendData[key]), dontshow: true);
                 }
-                else if (prompt.AskBool("Diff Mode", requirements.Defaults.DiffMode,
-                                        "On", "Off", out var diffModeAnswer))
+                else if (prompt.AskBool("Diff Mode",
+                                        defaultValue: requirements.Defaults.DiffMode,
+                                        trueHelpMessage: "On",
+                                        falseHelpMessage: "Off",
+                                        out var diffModeAnswer))
                 {
                     if (!diffModeAnswer.IsEmpty)
                         sendData[key] = diffModeAnswer.Input;
@@ -732,8 +746,10 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Job Tags", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("Job Tags", requirements.Defaults.JobTags,
-                                    "", out var jobTagsAnswer))
+                else if (prompt.Ask("Job Tags",
+                                    defaultValue: requirements.Defaults.JobTags,
+                                    helpMessage: "",
+                                    out var jobTagsAnswer))
                 {
                     if (!jobTagsAnswer.IsEmpty)
                         sendData[key] = jobTagsAnswer.Input;
@@ -749,8 +765,10 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Skip Tags", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("Skip Tags", requirements.Defaults.JobTags,
-                                    "", out var skipTagsAnswer))
+                else if (prompt.Ask("Skip Tags",
+                                    defaultValue: requirements.Defaults.JobTags,
+                                    helpMessage: "",
+                                    out var skipTagsAnswer))
                 {
                     if (!skipTagsAnswer.IsEmpty)
                         sendData[key] = skipTagsAnswer.Input;
@@ -766,8 +784,10 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Extra Vars", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("ExtraVariables", requirements.Defaults.ExtraVars,
-                            "", out var extraVarsAnswer))
+                else if (prompt.Ask("ExtraVariables",
+                                    defaultValue: requirements.Defaults.ExtraVars,
+                                    helpMessage: "",
+                                    out var extraVarsAnswer))
                 {
                     if (!extraVarsAnswer.IsEmpty)
                         sendData[key] = extraVarsAnswer.Input;

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -555,8 +555,8 @@ namespace AWX.Cmdlets
                                            required: false,
                                            out var eeAnswer))
                 {
-                    if (!eeAnswer.IsEmpty && eeAnswer.Input > 0)
-                        sendData[key] = eeAnswer.Input;
+                    if (!eeAnswer.IsEmpty)
+                        sendData[key] = eeAnswer.Input > 0 ? eeAnswer.Input : null;
                 }
                 else { return false; }
             }

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -571,8 +571,8 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.AskBool("Job Type",
                                         defaultValue: requirements.Defaults.JobType == Resources.JobType.Run,
-                                        trueHelpMessage: "Run",
-                                        falseHelpMessage: "Check",
+                                        trueParameter: ("Run", "Run: Execut the playbook when launched, running Ansible tasks on the selected hosts."),
+                                        falseParameter: ("Check", "Check: Perform a \"dry run\" of the playbook. This is same as `-C` -or `--check` command-line parameter for `ansible-playbook`"),
                                         out var jobTypeAnswer))
                 {
                     if (!jobTypeAnswer.IsEmpty)
@@ -736,8 +736,8 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.AskBool("Diff Mode",
                                         defaultValue: requirements.Defaults.DiffMode,
-                                        trueHelpMessage: "On",
-                                        falseHelpMessage: "Off",
+                                        trueParameter: ("On", "On: Allows to see the changes made by Ansible tasks. This is same as `-D` or `--diff` command-line parameter for `ansible-playbook`."),
+                                        falseParameter: ("Off", "Off"),
                                         out var diffModeAnswer))
                 {
                     if (!diffModeAnswer.IsEmpty)

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -347,7 +347,7 @@ namespace AWX.Cmdlets
             ulong[] credentialIds;
             if (sendData.TryGetValue("credentials", out var res))
             {
-                credentialIds = (res as List<ulong>)?.ToArray() ?? [];
+                credentialIds = res as ulong[] ?? [];
                 if (credentialIds.Length == 0)
                     return false;
 
@@ -524,7 +524,9 @@ namespace AWX.Cmdlets
                                                out var credentialsAnswer))
                 {
                     if (!credentialsAnswer.IsEmpty)
-                        sendData[key] = credentialsAnswer.Input;
+                        sendData[key] = credentialsAnswer.Input
+                                                         .Where(x => x > 0)
+                                                         .ToArray();
                 }
                 else { return false; }
             }
@@ -614,7 +616,9 @@ namespace AWX.Cmdlets
                                                out var labelsAnswer))
                 {
                     if (!labelsAnswer.IsEmpty)
-                        sendData[key] = labelsAnswer.Input;
+                        sendData[key] = labelsAnswer.Input
+                                                    .Where(x => x > 0)
+                                                    .ToArray();
                 }
                 else { return false; }
             }

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -497,10 +497,13 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Inventory", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<ulong>("Inventory", requirements.Defaults.Inventory.Id,
-                                           "", out var inventoryAnswer))
+                else if (prompt.Ask<ulong>("Inventory",
+                                           defaultValue: requirements.Defaults.Inventory.Id ?? 0,
+                                           helpMessage: "",
+                                           required: requirements.InventoryNeededToStart,
+                                           out var inventoryAnswer))
                 {
-                    if (!inventoryAnswer.IsEmpty)
+                    if (!inventoryAnswer.IsEmpty && inventoryAnswer.Input > 0)
                         sendData[key] = inventoryAnswer.Input;
                 }
                 else { return false; }
@@ -543,10 +546,12 @@ namespace AWX.Cmdlets
                     WriteHost(string.Format(skipFormat, "Execution Environment", sendData[key]), dontshow: true);
                 }
                 else if (prompt.Ask<ulong>("Execution Environment",
-                                           requirements.Defaults.ExecutionEnvironment.Id,
-                                           "", out var eeAnswer))
+                                           defaultValue: requirements.Defaults.ExecutionEnvironment.Id ?? 0,
+                                           helpMessage: "",
+                                           required: false,
+                                           out var eeAnswer))
                 {
-                    if (!eeAnswer.IsEmpty)
+                    if (!eeAnswer.IsEmpty && eeAnswer.Input > 0)
                         sendData[key] = eeAnswer.Input;
                 }
                 else { return false; }
@@ -615,8 +620,11 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Forks", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<int>("Forks", requirements.Defaults.Forks,
-                                         "", out var forksAnswer))
+                else if (prompt.Ask<int>("Forks",
+                                         defaultValue: requirements.Defaults.Forks,
+                                         helpMessage: "",
+                                         required: false,
+                                         out var forksAnswer))
                 {
                     if (!forksAnswer.IsEmpty)
                         sendData[key] = forksAnswer.Input;
@@ -667,8 +675,11 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Job Slice Count", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<int>("Job Slice Count", requirements.Defaults.JobSliceCount,
-                                         "", out var jobSliceCountAnswer))
+                else if (prompt.Ask<int>("Job Slice Count",
+                                         defaultValue: requirements.Defaults.JobSliceCount,
+                                         helpMessage: "",
+                                         required: false,
+                                         out var jobSliceCountAnswer))
                 {
                     if (!jobSliceCountAnswer.IsEmpty)
                         sendData[key] = jobSliceCountAnswer.Input;
@@ -684,8 +695,11 @@ namespace AWX.Cmdlets
                 {
                     WriteHost(string.Format(skipFormat, "Timeout", sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<int>("Timeout", requirements.Defaults.JobSliceCount,
-                                         "", out var timeoutAnswer))
+                else if (prompt.Ask<int>("Timeout",
+                                         defaultValue: requirements.Defaults.Timeout,
+                                         helpMessage: "",
+                                         required: false,
+                                         out var timeoutAnswer))
                 {
                     if (!timeoutAnswer.IsEmpty)
                         sendData[key] = timeoutAnswer.Input;

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -498,7 +498,7 @@ namespace AWX.Cmdlets
                     WriteHost(string.Format(skipFormat, "Inventory", sendData[key]), dontshow: true);
                 }
                 else if (prompt.Ask<ulong>("Inventory",
-                                           defaultValue: requirements.Defaults.Inventory.Id ?? 0,
+                                           defaultValue: requirements.Defaults.Inventory.Id,
                                            helpMessage: "",
                                            required: requirements.InventoryNeededToStart,
                                            out var inventoryAnswer))
@@ -549,7 +549,7 @@ namespace AWX.Cmdlets
                     WriteHost(string.Format(skipFormat, "Execution Environment", sendData[key]), dontshow: true);
                 }
                 else if (prompt.Ask<ulong>("Execution Environment",
-                                           defaultValue: requirements.Defaults.ExecutionEnvironment.Id ?? 0,
+                                           defaultValue: requirements.Defaults.ExecutionEnvironment.Id,
                                            helpMessage: "",
                                            required: false,
                                            out var eeAnswer))

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -487,17 +487,18 @@ namespace AWX.Cmdlets
             }
             var prompt = new AskPrompt(CommandRuntime.Host);
             string key;
+            string label;
             string skipFormat = "Skip {0} prompt. Already specified: {1:g}";
 
             // Inventory
             if (requirements.InventoryNeededToStart || (checkOptional && requirements.AskInventoryOnLaunch))
             {
-                key = "inventory";
+                key = "inventory"; label = "Inventory";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Inventory", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<ulong>("Inventory",
+                else if (prompt.Ask<ulong>(label,
                                            defaultValue: requirements.Defaults.Inventory.Id,
                                            helpMessage: "Input an Inventory ID."
                                                         + (requirements.InventoryNeededToStart ? " (Required)" : ""),
@@ -513,13 +514,13 @@ namespace AWX.Cmdlets
             // Credentials
             if (requirements.CredentialNeededToStart || (checkOptional &&  requirements.AskCredentialOnLaunch))
             {
-                key = "credentials";
+                key = "credentials"; label = "Credentials";
                 if (sendData.ContainsKey(key))
                 {
                     var strData = $"[{string.Join(", ", (ulong[]?)sendData[key] ?? [])}]";
-                    WriteHost(string.Format(skipFormat, "Credentials", strData), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, strData), dontshow: true);
                 }
-                else if (prompt.AskList<ulong>("Credentials",
+                else if (prompt.AskList<ulong>(label,
                                                defaultValues: requirements.Defaults.Credentials?.Select(x => $"[{x.Id}] {x.Name}"),
                                                helpMessage: "Enter Credential ID(s).",
                                                out var credentialsAnswer))
@@ -544,12 +545,12 @@ namespace AWX.Cmdlets
             // ExecutionEnvironment
             if (checkOptional && requirements.AskExecutionEnvironmentOnLaunch)
             {
-                key = "execution_environment";
+                key = "execution_environment"; label = "Execution Environment";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Execution Environment", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<ulong>("Execution Environment",
+                else if (prompt.Ask<ulong>(label,
                                            defaultValue: requirements.Defaults.ExecutionEnvironment.Id,
                                            helpMessage: "Enter the Execution Environment ID.",
                                            required: false,
@@ -564,12 +565,12 @@ namespace AWX.Cmdlets
             // JobType
             if (checkOptional && requirements.AskJobTypeOnLaunch)
             {
-                key = "job_type";
+                key = "job_type"; label = "Job Type";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Job Type", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.AskBool("Job Type",
+                else if (prompt.AskBool(label,
                                         defaultValue: requirements.Defaults.JobType == Resources.JobType.Run,
                                         trueParameter: ("Run", "Run: Execut the playbook when launched, running Ansible tasks on the selected hosts."),
                                         falseParameter: ("Check", "Check: Perform a \"dry run\" of the playbook. This is same as `-C` -or `--check` command-line parameter for `ansible-playbook`"),
@@ -586,12 +587,12 @@ namespace AWX.Cmdlets
             // ScmBranch
             if (checkOptional && requirements.AskScmBranchOnLaunch)
             {
-                key = "scm_branch";
+                key = "scm_branch"; label = "ScmBranch";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "ScmBranch", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("ScmBranch",
+                else if (prompt.Ask(label,
                                     defaultValue: requirements.Defaults.ScmBranch,
                                     helpMessage: "Enter the SCM branch name (or commit hash or tag)",
                                     out var branchAnswer))
@@ -605,13 +606,13 @@ namespace AWX.Cmdlets
             // Labels
             if (checkOptional && requirements.AskLabelsOnLaunch)
             {
-                key = "labels";
+                key = "labels"; label = "Labels";
                 if (sendData.ContainsKey(key))
                 {
                     var strData = $"[{string.Join(", ", (ulong[]?)sendData[key] ?? [])}]";
-                    WriteHost(string.Format(skipFormat, "Labels", strData), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, strData), dontshow: true);
                 }
-                else if (prompt.AskList<ulong>("Labels",
+                else if (prompt.AskList<ulong>(label,
                                                defaultValues: requirements.Defaults.Labels?.Select(x => $"[{x.Id}] {x.Name}") ?? [],
                                                helpMessage: "Enter Label ID(s).",
                                                out var labelsAnswer))
@@ -627,12 +628,12 @@ namespace AWX.Cmdlets
             // Forks
             if (checkOptional && requirements.AskForksOnLaunch)
             {
-                key = "forks";
+                key = "forks"; label = "Forks";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Forks", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<int>("Forks",
+                else if (prompt.Ask<int>(label,
                                          defaultValue: requirements.Defaults.Forks,
                                          helpMessage: "Enter the number of parallel or simultaneous procecces.",
                                          required: false,
@@ -647,12 +648,12 @@ namespace AWX.Cmdlets
             // Limit
             if (checkOptional && requirements.AskLimitOnLaunch)
             {
-                key = "limit";
+                key = "limit"; label = "Limit";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Limit", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("Limit",
+                else if (prompt.Ask(label,
                                     defaultValue: requirements.Defaults.Limit,
                                     helpMessage: """
                                     Enter the host pattern to further constrain the list of host managed or affected by the playbook.
@@ -669,13 +670,13 @@ namespace AWX.Cmdlets
             // Verbosity
             if (checkOptional && requirements.AskVerbosityOnLaunch)
             {
-                key = "verbosity";
+                key = "verbosity"; label = "Verbosity";
                 if (sendData.ContainsKey(key))
                 {
                     var v = (JobVerbosity)((int)(sendData[key] ?? 0));
-                    WriteHost(string.Format(skipFormat, "Job Tags", $"{v:d} ({v:g})"), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, $"{v:d} ({v:g})"), dontshow: true);
                 }
-                else if (prompt.AskEnum<JobVerbosity>("Verbosity",
+                else if (prompt.AskEnum<JobVerbosity>(label,
                                                       defaultValue: requirements.Defaults.Verbosity,
                                                       helpMessage: "Choose the job log verbosity level.",
                                                       out var verbosityAnswer))
@@ -689,12 +690,12 @@ namespace AWX.Cmdlets
             // JobSliceCount
             if (checkOptional && requirements.AskJobTypeOnLaunch)
             {
-                key = "job_slice_count";
+                key = "job_slice_count"; label = "Job Slice Count";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Job Slice Count", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<int>("Job Slice Count",
+                else if (prompt.Ask<int>(label,
                                          defaultValue: requirements.Defaults.JobSliceCount,
                                          helpMessage: "Enter the number of slices you want this job template to run.",
                                          required: false,
@@ -709,12 +710,12 @@ namespace AWX.Cmdlets
             // Timeout
             if (checkOptional && requirements.AskTimeoutOnLaunch)
             {
-                key = "timeout";
+                key = "timeout"; label = "Timeout";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Timeout", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask<int>("Timeout",
+                else if (prompt.Ask<int>(label,
                                          defaultValue: requirements.Defaults.Timeout,
                                          helpMessage: "Enter the timeout value(seconds).",
                                          required: false,
@@ -729,12 +730,12 @@ namespace AWX.Cmdlets
             // DiffMode
             if (checkOptional && requirements.AskDiffModeOnLaunch)
             {
-                key = "diff_mode";
+                key = "diff_mode"; label = "Diff Mode";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Diff Mode", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.AskBool("Diff Mode",
+                else if (prompt.AskBool(label,
                                         defaultValue: requirements.Defaults.DiffMode,
                                         trueParameter: ("On", "On: Allows to see the changes made by Ansible tasks. This is same as `-D` or `--diff` command-line parameter for `ansible-playbook`."),
                                         falseParameter: ("Off", "Off"),
@@ -749,12 +750,12 @@ namespace AWX.Cmdlets
             // Tags
             if (checkOptional && requirements.AskTagsOnLaunch)
             {
-                key = "job_tags";
+                key = "job_tags"; label = "Job Tags";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Job Tags", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("Job Tags",
+                else if (prompt.Ask(label,
                                     defaultValue: requirements.Defaults.JobTags,
                                     helpMessage: """
                                     Enter the tags. Multiple values can be separated by commas(`,`).
@@ -771,12 +772,12 @@ namespace AWX.Cmdlets
             // SkipTags
             if (checkOptional && requirements.AskSkipTagsOnLaunch)
             {
-                key = "skip_tags";
+                key = "skip_tags"; label = "Skip Tags";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Skip Tags", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("Skip Tags",
+                else if (prompt.Ask(label,
                                     defaultValue: requirements.Defaults.JobTags,
                                     helpMessage: """
                                     Enter the skip tags. Multiple values can be separated by commas(`,`).
@@ -793,12 +794,12 @@ namespace AWX.Cmdlets
             // ExtraVars
             if (checkOptional && requirements.AskVariablesOnLaunch)
             {
-                key = "extra_vars";
+                key = "extra_vars"; label = "Extra Variables";
                 if (sendData.ContainsKey(key))
                 {
-                    WriteHost(string.Format(skipFormat, "Extra Vars", sendData[key]), dontshow: true);
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
                 }
-                else if (prompt.Ask("ExtraVariables",
+                else if (prompt.Ask(label,
                                     defaultValue: requirements.Defaults.ExtraVars,
                                     helpMessage: """
                                     Enter the extra variables provided key/value pairs using either YAML or JSON, to be passed to the playbook.

--- a/src/Cmdlets/JobTemplateCommand.cs
+++ b/src/Cmdlets/JobTemplateCommand.cs
@@ -499,7 +499,8 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask<ulong>("Inventory",
                                            defaultValue: requirements.Defaults.Inventory.Id,
-                                           helpMessage: "",
+                                           helpMessage: "Input an Inventory ID."
+                                                        + (requirements.InventoryNeededToStart ? " (Required)" : ""),
                                            required: requirements.InventoryNeededToStart,
                                            out var inventoryAnswer))
                 {
@@ -520,7 +521,7 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.AskList<ulong>("Credentials",
                                                defaultValues: requirements.Defaults.Credentials?.Select(x => $"[{x.Id}] {x.Name}"),
-                                               helpMessage: "",
+                                               helpMessage: "Enter Credential ID(s).",
                                                out var credentialsAnswer))
                 {
                     if (!credentialsAnswer.IsEmpty)
@@ -550,7 +551,7 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask<ulong>("Execution Environment",
                                            defaultValue: requirements.Defaults.ExecutionEnvironment.Id,
-                                           helpMessage: "",
+                                           helpMessage: "Enter the Execution Environment ID.",
                                            required: false,
                                            out var eeAnswer))
                 {
@@ -592,7 +593,7 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask("ScmBranch",
                                     defaultValue: requirements.Defaults.ScmBranch,
-                                    helpMessage: "",
+                                    helpMessage: "Enter the SCM branch name (or commit hash or tag)",
                                     out var branchAnswer))
                 {
                     if (!branchAnswer.IsEmpty)
@@ -612,7 +613,7 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.AskList<ulong>("Labels",
                                                defaultValues: requirements.Defaults.Labels?.Select(x => $"[{x.Id}] {x.Name}") ?? [],
-                                               helpMessage: "",
+                                               helpMessage: "Enter Label ID(s).",
                                                out var labelsAnswer))
                 {
                     if (!labelsAnswer.IsEmpty)
@@ -633,7 +634,7 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask<int>("Forks",
                                          defaultValue: requirements.Defaults.Forks,
-                                         helpMessage: "",
+                                         helpMessage: "Enter the number of parallel or simultaneous procecces.",
                                          required: false,
                                          out var forksAnswer))
                 {
@@ -653,7 +654,10 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask("Limit",
                                     defaultValue: requirements.Defaults.Limit,
-                                    helpMessage: "",
+                                    helpMessage: """
+                                    Enter the host pattern to further constrain the list of host managed or affected by the playbook.
+                                    Multiple patterns can be separated by commas(`,`) or colons(`:`).
+                                    """,
                                     out var limitAnswer))
                 {
                     if (!limitAnswer.IsEmpty)
@@ -673,7 +677,7 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.AskEnum<JobVerbosity>("Verbosity",
                                                       defaultValue: requirements.Defaults.Verbosity,
-                                                      helpMessage: "",
+                                                      helpMessage: "Choose the job log verbosity level.",
                                                       out var verbosityAnswer))
                 {
                     if (!verbosityAnswer.IsEmpty)
@@ -692,7 +696,7 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask<int>("Job Slice Count",
                                          defaultValue: requirements.Defaults.JobSliceCount,
-                                         helpMessage: "",
+                                         helpMessage: "Enter the number of slices you want this job template to run.",
                                          required: false,
                                          out var jobSliceCountAnswer))
                 {
@@ -712,7 +716,7 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask<int>("Timeout",
                                          defaultValue: requirements.Defaults.Timeout,
-                                         helpMessage: "",
+                                         helpMessage: "Enter the timeout value(seconds).",
                                          required: false,
                                          out var timeoutAnswer))
                 {
@@ -752,7 +756,10 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask("Job Tags",
                                     defaultValue: requirements.Defaults.JobTags,
-                                    helpMessage: "",
+                                    helpMessage: """
+                                    Enter the tags. Multiple values can be separated by commas(`,`).
+                                    This is same as the `--tags` command-line parameter for `ansible-playbook`.
+                                    """,
                                     out var jobTagsAnswer))
                 {
                     if (!jobTagsAnswer.IsEmpty)
@@ -771,7 +778,10 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask("Skip Tags",
                                     defaultValue: requirements.Defaults.JobTags,
-                                    helpMessage: "",
+                                    helpMessage: """
+                                    Enter the skip tags. Multiple values can be separated by commas(`,`).
+                                    This is same as the `--skip-tags` command-line parameter for `ansible-playbook`.
+                                    """,
                                     out var skipTagsAnswer))
                 {
                     if (!skipTagsAnswer.IsEmpty)
@@ -790,7 +800,10 @@ namespace AWX.Cmdlets
                 }
                 else if (prompt.Ask("ExtraVariables",
                                     defaultValue: requirements.Defaults.ExtraVars,
-                                    helpMessage: "",
+                                    helpMessage: """
+                                    Enter the extra variables provided key/value pairs using either YAML or JSON, to be passed to the playbook.
+                                    This is same as the `-e` or `--extra-vars` command-line parameter for `ansible-playbook`.
+                                    """,
                                     out var extraVarsAnswer))
                 {
                     if (!extraVarsAnswer.IsEmpty)

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -1,0 +1,252 @@
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+
+namespace AWX.Cmdlets
+{
+    internal class AskPrompt
+    {
+        public AskPrompt(PSHost host)
+        {
+            _host = host;
+        }
+        private PSHost _host { get; }
+
+        private void printHeader(string label, string defaultValue, string help)
+        {
+            var gb = Console.BackgroundColor;
+            _host.UI.WriteLine();
+            _host.UI.Write(ConsoleColor.Blue, gb, "==> ");
+            _host.UI.WriteLine($"Enter {label} (Default: {defaultValue})");
+            _host.UI.WriteLine(ConsoleColor.DarkYellow, gb, help);
+
+        }
+        private void printHelp(string label, string message, string help)
+        {
+            var gb = Console.BackgroundColor;
+            _host.UI.Write(ConsoleColor.Blue, gb, "==> ");
+            _host.UI.WriteLine(label);
+            _host.UI.WriteLine(message);
+            _host.UI.WriteLine(ConsoleColor.DarkYellow, gb, help);
+        }
+        /// <summary>
+        /// List input prompt
+        /// </summary>
+        /// <param name="label">Prompt label</param>
+        /// <param name="defaultValues"></param>
+        /// <param name="answers"></param>
+        /// <returns>Whether the prompt is inputed(<c>true</c>) or Canceled(<c>false</c>)</returns>
+        public bool AskList<T>(string label, IEnumerable<string>? defaultValues, out Answer<List<T>> answers)
+        {
+            var results = new List<T>();
+            var index = 0;
+            var defaultValuString = $"[{string.Join(", ", defaultValues ?? [])}]";
+            var help = "(Type !? : Show help, !> : Suspend)";
+            printHeader(label, defaultValuString, help);
+            do
+            {
+                var fieldLabel = $"{label}[{index}]";
+                var currentHelpMessage = $"CurrentValues: [{string.Join(", ", results.Select(item => $"{item}"))}]";
+                if (!TryPromptOneInput(fieldLabel, out var inputString))
+                {
+                    answers = new Answer<List<T>>([], true);
+                    return false;
+                }
+                if (inputString.StartsWith('!'))
+                {
+                    var command = inputString.Substring(1).Trim();
+                    switch (command)
+                    {
+                        case "?":
+                            printHelp(label, currentHelpMessage, help);
+                            continue;
+                        case ">":
+                            _host.EnterNestedPrompt();
+                            continue;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(inputString))
+                {
+                    answers = new Answer<List<T>>(results);
+                    return true;
+                }
+                else
+                {
+                    try
+                    {
+                        var val = LanguagePrimitives.ConvertTo<T>(inputString);
+                        results.Add(val);
+                        index = results.Count;
+                    }
+                    catch (Exception ex)
+                    {
+                        _host.UI.WriteLine(ConsoleColor.Red, Console.BackgroundColor, ex.Message);
+                    }
+                }
+            }
+            while (true);
+        }
+        /// <summary>
+        /// String input prompt
+        /// </summary>
+        /// <param name="label">Prompt label</param>
+        /// <param name="defaultValue"></param>
+        /// <param name="answer"></param>
+        /// <returns>Whether the prompt is inputed(<c>true</c>) or Canceled(<c>false</c>)</returns>
+        public bool Ask(string label, string? defaultValue, out Answer<string> answer)
+        {
+            var defaultValueString = $"\"{defaultValue}\"";
+            var help = """
+                (!? => Show help, !! => Use default, !> => Suspend, Empty => Skip, ("", '', $null) => Specify empty string)
+                """;
+            printHeader(label, defaultValueString, help);
+            do
+            {
+                var inputed = false;
+                if (!TryPromptOneInput(label, out var inputString))
+                {
+                    answer = new Answer<string>(string.Empty, true);
+                    return false;
+                }
+                if (inputString.StartsWith('!'))
+                {
+                    var command = inputString.Substring(1).Trim();
+                    switch (command)
+                    {
+                        case "?":
+                            printHelp(label, $"Default: {defaultValueString}", help);
+                            continue;
+                        case "!":
+                            answer = new Answer<string>(defaultValue ?? string.Empty);
+                            return true;
+                        case ">":
+                            _host.EnterNestedPrompt();
+                            continue;
+                        default:
+                            inputString = command;
+                            break;
+                    }
+                }
+                switch (inputString)
+                {
+                    case "\"\"":
+                    case "''":
+                    case "$null":
+                        inputed = true;
+                        inputString = string.Empty;
+                        break;
+
+                }
+                if (string.IsNullOrEmpty(inputString))
+                {
+                    answer = new Answer<string>(defaultValue ?? string.Empty, !inputed);
+                    return true;
+                }
+                else
+                {
+                    answer = new Answer<string>(inputString);
+                    return true;
+                }
+            }
+            while (true);
+        }
+        /// <summary>
+        /// Number input prompt
+        /// </summary>
+        /// <typeparam name="T">inputed data type (mainly number type)</typeparam>
+        /// <param name="label">Prompt label</param>
+        /// <param name="defaultValue"></param>
+        /// <param name="answer"></param>
+        /// <returns>Whether the prompt is inputed(<c>true</c>) or Canceled(<c>false</c>)</returns>
+        public bool Ask<T>(string label, T? defaultValue, out Answer<T> answer) where T : struct
+        {
+            var help = """
+                (!? => Show help, !! => Use default, !> => Suspend, Empty => Skip)
+                """;
+            printHeader(label, $"{defaultValue}", help);
+            do
+            {
+                var inputed = false;
+                if (!TryPromptOneInput(label, out var inputString))
+                {
+                    answer = new Answer<T>(default(T), true);
+                    return false;
+                }
+                if (inputString.StartsWith('!'))
+                {
+                    var command = inputString.Substring(1).Trim();
+                    switch (command)
+                    {
+                        case "?":
+                            printHelp(label, $"Default: {defaultValue}", help);
+                            continue;
+                        case "!":
+                            inputed = true;
+                            inputString = string.Empty;
+                            break;
+                        case ">":
+                            _host.EnterNestedPrompt();
+                            continue;
+                        default:
+                            inputString = command;
+                            break;
+                    }
+                }
+                if (string.IsNullOrEmpty(inputString))
+                {
+                    if (defaultValue != null)
+                    {
+                        answer = new Answer<T>((T)defaultValue, !inputed);
+                        return true;
+                    }
+                    _host.UI.Write(ConsoleColor.Red, Console.BackgroundColor,
+                            $"default value is null. Please specify value.\n");
+                    continue;
+                }
+                else
+                {
+                    try
+                    {
+                        answer = new Answer<T>(LanguagePrimitives.ConvertTo<T>(inputString));
+                        return true;
+                    }
+                    catch(Exception ex)
+                    {
+                        _host.UI.WriteLine(ConsoleColor.Red, Console.BackgroundColor, ex.Message);
+                    }
+                }
+            }
+            while (true);
+        }
+        private bool TryPromptOneInput(string label, out string inputString)
+        {
+            inputString = string.Empty;
+            var fd = new FieldDescription(label);
+            fd.SetParameterType(typeof(string));
+            var fdc = new Collection<FieldDescription>() { fd };
+            Dictionary<string, PSObject?>? result = _host.UI.Prompt("", "", fdc);
+            if (result != null && result.TryGetValue(label, out PSObject? val))
+            {
+                if (val == null || val.BaseObject == null)
+                {
+                    return false;
+                }
+                inputString = val.BaseObject as string ?? string.Empty;
+                return true;
+            }
+            return false;
+        }
+
+        public class Answer<T>
+        {
+            public Answer(T input, bool isEmpty = false)
+            {
+                Input = input;
+                IsEmpty = isEmpty;
+            }
+            public T Input { get; }
+            public bool IsEmpty { get; }
+        }
+    }
+}

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -69,7 +69,7 @@ namespace AWX.Cmdlets
             var results = new List<T>();
             var index = 0;
             var defaultValuString = $"[{string.Join(", ", defaultValues ?? [])}]";
-            var helpIndicator = "(Type !? : Show help, !> : Suspend)";
+            var helpIndicator = "(!? => Show help, !> => Suspend, !! => Comfirm even if the list is empty)";
             printHeader(label, defaultValuString, helpMessage, helpIndicator);
             do
             {
@@ -89,6 +89,9 @@ namespace AWX.Cmdlets
                         case "?":
                             printHelp(label, currentHelpMessage, helpIndicator);
                             continue;
+                        case "!": // return as the list is fulfilled even if the list is empty.
+                            answers = new Answer<List<T>>(results, false);
+                            return true;
                         case ">":
                             _host.EnterNestedPrompt();
                             continue;
@@ -151,7 +154,7 @@ namespace AWX.Cmdlets
                             printHelp(label, help, helpIndicator);
                             continue;
                         case "!":
-                            answer = new Answer<string>(defaultValue ?? string.Empty);
+                            answer = new Answer<string>(string.Empty);
                             return true;
                         case ">":
                             _host.EnterNestedPrompt();

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -272,6 +272,45 @@ namespace AWX.Cmdlets
             }
 
         }
+        /// <summary>
+        /// String input prompt
+        /// </summary>
+        /// <typeparam name="TEnum">inputed data type (Enum)</typeparam>
+        /// <param name="label">Prompt label</param>
+        /// <param name="answer"></param>
+        /// <param name="helpMessage"></param>
+        /// <param name="defaultValue"</param>
+        /// <returns>Whether the prompt is inputed(<c>true</c>) or Canceled(<c>false</c>)</returns>
+        public bool AskEnum<TEnum>(string label, TEnum defaultValue, string helpMessage, out Answer<TEnum> answer) where TEnum : System.Enum
+        {
+            var defaultValueString = $"{defaultValue:g} ({defaultValue:d})";
+            printHeader(label, defaultValueString, helpMessage);
+            var choices = new Collection<ChoiceDescription>();
+            var defaultValueIndex = -1;
+            var enumType = typeof(TEnum);
+
+            var list = new List<TEnum>();
+            var enumValues = Enum.GetValues(enumType);
+            foreach (TEnum val in enumValues)
+            {
+                var num = $"{val:d}";
+                var str = $"{val:g}";
+                if (str == $"{defaultValue}")
+                {
+                    defaultValueIndex = choices.Count;
+                }
+                choices.Add(new ChoiceDescription($"&{str}", $"[{num}] {str}"));
+                list.Add(val);
+            }
+            var res = _host.UI.PromptForChoice("", "", choices, defaultValueIndex);
+            if (res >= 0 && res < list.Count)
+            {
+                answer = new Answer<TEnum>(list[res]);
+                return true;
+            }
+            answer = new Answer<TEnum>(defaultValue, true);
+            return false;
+        }
         private bool TryPromptOneInput(string label, out string inputString)
         {
             inputString = string.Empty;

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -17,7 +17,7 @@ namespace AWX.Cmdlets
         private void printHeader(string label, string defaultValue, string helpMessage = "", string helpIndicator = "", bool showDefault = true)
         {
             var gb = Console.BackgroundColor;
-            _host.UI.Write(ConsoleColor.Blue, gb, "==> ");
+            _host.UI.Write(ConsoleColor.Blue, gb, "<== ");
             _host.UI.Write($"{label}");
             if (showDefault)
             {
@@ -45,7 +45,7 @@ namespace AWX.Cmdlets
         private void printHelp(string label, string helpMessage = "", string helpIndicator = "")
         {
             var gb = Console.BackgroundColor;
-            _host.UI.Write(ConsoleColor.Blue, gb, "==> ");
+            _host.UI.Write(ConsoleColor.Blue, gb, "<== ");
             _host.UI.WriteLine(label);
             if (!string.IsNullOrEmpty(helpMessage))
             {

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -240,6 +240,38 @@ namespace AWX.Cmdlets
             }
             while (true);
         }
+        /// <summary>
+        /// Boolean input prompt
+        /// </summary>
+        /// <param name="label">Prompt label</param>
+        /// <param name="answer"></param>
+        /// <param name="trueHelpMessage"></param>
+        /// <param name="falseHelpMessage"></param>
+        /// <param name="defaultValue"</param>
+        /// <returns>Whether the prompt is inputed(<c>true</c>) or Canceled(<c>false</c>)</returns>
+        public bool AskBool(string label, bool defaultValue, string trueHelpMessage, string falseHelpMessage, out Answer<bool> answer)
+        {
+            var choices = new Collection<ChoiceDescription>();
+
+            choices.Add(new ChoiceDescription("&True", trueHelpMessage));
+            choices.Add(new ChoiceDescription("&False", falseHelpMessage));
+
+            printHeader(label, "", $"{trueHelpMessage}(true) or {falseHelpMessage}(false)");
+            var res = _host.UI.PromptForChoice("", "", choices, defaultValue ? 0 : 1);
+            switch (res)
+            {
+                case 0:
+                    answer = new Answer<bool>(true);
+                    return true;
+                case 1:
+                    answer = new Answer<bool>(false);
+                    return true;
+                default:
+                    answer = new Answer<bool>(false);
+                    return false;
+            }
+
+        }
         private bool TryPromptOneInput(string label, out string inputString)
         {
             inputString = string.Empty;

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -186,9 +186,10 @@ namespace AWX.Cmdlets
         /// <param name="label">Prompt label</param>
         /// <param name="defaultValue"></param>
         /// <param name="helpMessage"></param>
+        /// <param name="required"></param>
         /// <param name="answer"></param>
         /// <returns>Whether the prompt is inputed(<c>true</c>) or Canceled(<c>false</c>)</returns>
-        public bool Ask<T>(string label, T? defaultValue, string helpMessage, out Answer<T> answer) where T : struct
+        public bool Ask<T>(string label, T defaultValue, string helpMessage, bool required, out Answer<T> answer) where T: struct
         {
             var helpIndicator = """
                 (!? => Show help, !! => Use default, !> => Suspend, Empty => Skip)
@@ -226,14 +227,14 @@ namespace AWX.Cmdlets
                 }
                 if (string.IsNullOrEmpty(inputString))
                 {
-                    if (defaultValue != null)
+                    if (required)
                     {
-                        answer = new Answer<T>((T)defaultValue, !inputed);
-                        return true;
+                        _host.UI.WriteLine(ConsoleColor.Red, Console.BackgroundColor,
+                                           "Empty value is not allowed.");
+                        continue;
                     }
-                    _host.UI.Write(ConsoleColor.Red, Console.BackgroundColor,
-                            $"default value is null. Please specify value.\n");
-                    continue;
+                    answer = new Answer<T>((T)defaultValue, !inputed);
+                    return true;
                 }
                 else
                 {

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -282,18 +282,21 @@ namespace AWX.Cmdlets
         /// </summary>
         /// <param name="label">Prompt label</param>
         /// <param name="answer"></param>
-        /// <param name="trueHelpMessage"></param>
-        /// <param name="falseHelpMessage"></param>
+        /// <param name="trueParameter"></param>
+        /// <param name="falseParameter"></param>
         /// <param name="defaultValue"</param>
         /// <returns>Whether the prompt is inputed(<c>true</c>) or Canceled(<c>false</c>)</returns>
-        public bool AskBool(string label, bool defaultValue, string trueHelpMessage, string falseHelpMessage, out Answer<bool> answer)
+        public bool AskBool(string label, bool defaultValue,
+                            (string label, string helpMessage) trueParameter,
+                            (string label, string helpMessage) falseParameter,
+                            out Answer<bool> answer)
         {
             var choices = new Collection<ChoiceDescription>();
 
-            choices.Add(new ChoiceDescription("&True", trueHelpMessage));
-            choices.Add(new ChoiceDescription("&False", falseHelpMessage));
+            choices.Add(new ChoiceDescription($"{trueParameter.label} (&Yes)", trueParameter.helpMessage));
+            choices.Add(new ChoiceDescription($"{falseParameter.label} (&No)", falseParameter.helpMessage));
 
-            printHeader(label, "", $"{trueHelpMessage}(true) or {falseHelpMessage}(false)", showDefault: false);
+            printHeader(label, "", $"{trueParameter.label} (Yes) or {falseParameter.label} (No)", showDefault: false);
             var res = _host.UI.PromptForChoice("", "", choices, defaultValue ? 0 : 1);
             switch (res)
             {
@@ -304,7 +307,7 @@ namespace AWX.Cmdlets
                     answer = new Answer<bool>(false);
                     return true;
                 default:
-                    answer = new Answer<bool>(false);
+                    answer = new Answer<bool>(defaultValue);
                     return false;
             }
 

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -329,23 +329,20 @@ namespace AWX.Cmdlets
             var defaultValueIndex = -1;
             var enumType = typeof(TEnum);
 
-            var list = new List<TEnum>();
-            var enumValues = Enum.GetValues(enumType);
-            foreach (TEnum val in enumValues)
+            var enumValues = (TEnum[])Enum.GetValues(enumType);
+            for (var i = 0; i < enumValues.Length; i++)
             {
-                var num = $"{val:d}";
-                var str = $"{val:g}";
+                var str = $"{enumValues[i]:g}";
                 if (str == $"{defaultValue}")
                 {
-                    defaultValueIndex = choices.Count;
+                    defaultValueIndex = i;
                 }
-                choices.Add(new ChoiceDescription($"&{str}", $"[{num}] {str}"));
-                list.Add(val);
+                choices.Add(new ChoiceDescription($"{str}(&{i})", str));
             }
             var res = _host.UI.PromptForChoice("", "", choices, defaultValueIndex);
-            if (res >= 0 && res < list.Count)
+            if (res >= 0 && res < enumValues.Length)
             {
-                answer = new Answer<TEnum>(list[res]);
+                answer = new Answer<TEnum>(enumValues[res]);
                 return true;
             }
             answer = new Answer<TEnum>(defaultValue, true);

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -38,6 +38,10 @@ namespace AWX.Cmdlets
                 _host.UI.WriteLine(ConsoleColor.DarkYellow, gb, helpIndicator);
             }
         }
+        private void WriteError(string errorMessage)
+        {
+            _host.UI.WriteLine(ConsoleColor.Red, (ConsoleColor)(-1), errorMessage);
+        }
         private void printHelp(string label, string helpMessage = "", string helpIndicator = "")
         {
             var gb = Console.BackgroundColor;
@@ -106,7 +110,7 @@ namespace AWX.Cmdlets
                     }
                     catch (Exception ex)
                     {
-                        _host.UI.WriteLine(ConsoleColor.Red, Console.BackgroundColor, ex.Message);
+                        WriteError(ex.Message);
                     }
                 }
             }
@@ -229,8 +233,7 @@ namespace AWX.Cmdlets
                 {
                     if (required)
                     {
-                        _host.UI.WriteLine(ConsoleColor.Red, Console.BackgroundColor,
-                                           "Empty value is not allowed.");
+                        WriteError("Empty value is not allowed.");
                         continue;
                     }
                     answer = new Answer<T>((T)defaultValue, !inputed);
@@ -245,7 +248,7 @@ namespace AWX.Cmdlets
                     }
                     catch(Exception ex)
                     {
-                        _host.UI.WriteLine(ConsoleColor.Red, Console.BackgroundColor, ex.Message);
+                        WriteError(ex.Message);
                     }
                 }
             }

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -97,7 +97,8 @@ namespace AWX.Cmdlets
 
                 if (string.IsNullOrEmpty(inputString))
                 {
-                    answers = new Answer<List<T>>(results);
+                    var isEmpty = results.Count == 0;
+                    answers = new Answer<List<T>>(results, isEmpty);
                     return true;
                 }
                 else

--- a/src/Cmdlets/PromptHelper.cs
+++ b/src/Cmdlets/PromptHelper.cs
@@ -35,7 +35,7 @@ namespace AWX.Cmdlets
             }
             if (!string.IsNullOrEmpty(helpIndicator))
             {
-                _host.UI.WriteLine(ConsoleColor.DarkYellow, gb, helpIndicator);
+                _host.UI.WriteLine(ConsoleColor.DarkGray, gb, helpIndicator);
             }
         }
         private void WriteError(string errorMessage)
@@ -53,7 +53,7 @@ namespace AWX.Cmdlets
             }
             if (!string.IsNullOrEmpty(helpIndicator))
             {
-                _host.UI.WriteLine(ConsoleColor.DarkYellow, gb, helpIndicator);
+                _host.UI.WriteLine(ConsoleColor.DarkGray, gb, helpIndicator);
             }
         }
         /// <summary>


### PR DESCRIPTION
Add `-Interactive` paramater to  `Invoke-JobTempalte` and `Start-JobTemplate` cmdlets for inputing various parameter interactivly.

## Image
![image](https://github.com/user-attachments/assets/40d64bf9-7ab1-4430-8628-294fac03c25b)

## ToDo
- Write document: Filed to #27 .