### PR TITLE
:sparkles: Implement `Interactive` mode on WorkflowJobTemplate launcher

### DIFF
--- a/src/Cmdlets/WorkflowJobTemplateCommand.cs
+++ b/src/Cmdlets/WorkflowJobTemplateCommand.cs
@@ -94,6 +94,9 @@ namespace AWX.Cmdlets
         [Parameter()] // TODO: Should accept `IDctionary` (convert to JSON serialized string)
         public string? ExtraVars { get; set; }
 
+        [Parameter()]
+        public SwitchParameter Interactive { get; set; }
+
         private IDictionary<string, object?> CreateSendData()
         {
             var dict = new Dictionary<string, object?>();
@@ -223,6 +226,261 @@ namespace AWX.Cmdlets
                         $"[{string.Join(", ", requirements.NodePromptsRejected)}]");
             }
         }
+
+        private void PrintPromptResult(string label, string resultValue, bool notSpecified = false)
+        {
+            var ui = CommandRuntime.Host?.UI;
+            if (ui == null) return;
+            var bg = Console.BackgroundColor;
+            ui.Write(ConsoleColor.Green, bg, "==> ");
+            var sb = new StringBuilder();
+            if (notSpecified)
+            {
+                sb.Append($"Not specified {label}. Will be used default");
+            }
+            else
+            {
+                sb.Append($"Accepted {label}");
+            }
+            if (!string.IsNullOrEmpty(resultValue))
+            {
+                sb.Append($": {resultValue}");
+            }
+            WriteHost(sb.ToString());
+            ui.WriteLine("\n");
+        }
+
+        /// <summary>
+        /// Show input prompt and Update <paramref name="sendData"/>.
+        /// </summary>
+        /// <param name="requirements"></param>
+        /// <param name="sendData">Dictionary object that is the source of the JSON string sent to AWX/AnsibleTower</param>
+        /// <param name="checkOptional">
+        ///   <c>true</c>(`Interactive` mode)  => Check both <c>***NeededToStart</c> and <c>**AskInventoryOnLaunch</c>.
+        ///   <c>false</c> => Check only <c>***NeededToStart</c>.
+        /// </param>
+        /// <returns>Whether the prompt is inputed(<c>true</c>) or Canceled(<c>false</c>)</returns>
+        protected bool TryAskOnLaunch(WorkflowJobTemplateLaunchRequirements requirements,
+                                      IDictionary<string, object?> sendData,
+                                      bool checkOptional = false)
+        {
+            if (requirements.CanStartWithoutUserInput)
+            {
+                return true;
+            }
+            if (CommandRuntime.Host == null)
+            {
+                return false;
+            }
+            var prompt = new AskPrompt(CommandRuntime.Host);
+            string key;
+            string label;
+            string skipFormat = "Skip {0} prompt. Already specified: {1:g}";
+
+            // Inventory
+            if (checkOptional && requirements.AskInventoryOnLaunch)
+            {
+                key = "inventory"; label = "Inventory";
+                if (sendData.ContainsKey(key))
+                {
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
+                }
+                else if (prompt.Ask<ulong>(label,
+                                           defaultValue: requirements.Defaults.Inventory.Id,
+                                           helpMessage: "Input an Inventory ID.",
+                                           required: false,
+                                           out var inventoryAnswer))
+                {
+                    if (!inventoryAnswer.IsEmpty && inventoryAnswer.Input > 0)
+                    {
+                        sendData[key] = inventoryAnswer.Input;
+                        PrintPromptResult(label, $"{inventoryAnswer.Input}");
+                    }
+                    else
+                    {
+                        PrintPromptResult(label, $"{requirements.Defaults.Inventory}", true);
+                    }
+                }
+                else { return false; }
+            }
+
+            // ScmBranch
+            if (checkOptional && requirements.AskScmBranchOnLaunch)
+            {
+                key = "scm_branch"; label = "ScmBranch";
+                if (sendData.ContainsKey(key))
+                {
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
+                }
+                else if (prompt.Ask(label,
+                                    defaultValue: requirements.Defaults.ScmBranch,
+                                    helpMessage: "Enter the SCM branch name (or commit hash or tag)",
+                                    out var branchAnswer))
+                {
+                    if (!branchAnswer.IsEmpty)
+                    {
+                        sendData[key] = branchAnswer.Input;
+                        PrintPromptResult(label, $"\"{branchAnswer.Input}\"");
+                    }
+                    else
+                    {
+                        PrintPromptResult(label, $"\"{requirements.Defaults.ScmBranch}\"", true);
+                    }
+                }
+                else { return false; }
+            }
+
+            // Labels
+            if (checkOptional && requirements.AskLabelsOnLaunch)
+            {
+                key = "labels"; label = "Labels";
+                if (sendData.ContainsKey(key))
+                {
+                    var strData = $"[{string.Join(", ", (ulong[]?)sendData[key] ?? [])}]";
+                    WriteHost(string.Format(skipFormat, label, strData), dontshow: true);
+                }
+                else if (prompt.AskList<ulong>(label,
+                                               defaultValues: requirements.Defaults.Labels?.Select(x => $"[{x.Id}] {x.Name}") ?? [],
+                                               helpMessage: "Enter Label ID(s).",
+                                               out var labelsAnswer))
+                {
+                    if (!labelsAnswer.IsEmpty)
+                    {
+                        var arr = labelsAnswer.Input.Where(x => x > 0).ToArray();
+                        sendData[key] = arr;
+                        PrintPromptResult(label, $"[{string.Join(", ", arr)}]");
+                    }
+                    else
+                    {
+                        PrintPromptResult(label,
+                                    $"[{string.Join(", ", requirements.Defaults.Labels?.Select(x => $"{x}") ?? [])}]",
+                                    true);
+                    }
+                }
+                else { return false; }
+            }
+
+            // Limit
+            if (checkOptional && requirements.AskLimitOnLaunch)
+            {
+                key = "limit"; label = "Limit";
+                if (sendData.ContainsKey(key))
+                {
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
+                }
+                else if (prompt.Ask(label,
+                                    defaultValue: requirements.Defaults.Limit,
+                                    helpMessage: """
+                                    Enter the host pattern to further constrain the list of host managed or affected by the playbook.
+                                    Multiple patterns can be separated by commas(`,`) or colons(`:`).
+                                    """,
+                                    out var limitAnswer))
+                {
+                    if (!limitAnswer.IsEmpty)
+                    {
+                        sendData[key] = limitAnswer.Input;
+                        PrintPromptResult(label, $"\"{limitAnswer.Input}\"");
+                    }
+                    else
+                    {
+                        PrintPromptResult(label, $"\"{requirements.Defaults.Limit}\"", true);
+                    }
+                }
+                else { return false; }
+            }
+
+            // Tags
+            if (checkOptional && requirements.AskTagsOnLaunch)
+            {
+                key = "job_tags"; label = "Job Tags";
+                if (sendData.ContainsKey(key))
+                {
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
+                }
+                else if (prompt.Ask(label,
+                                    defaultValue: requirements.Defaults.JobTags,
+                                    helpMessage: """
+                                    Enter the tags. Multiple values can be separated by commas(`,`).
+                                    This is same as the `--tags` command-line parameter for `ansible-playbook`.
+                                    """,
+                                    out var jobTagsAnswer))
+                {
+                    if (!jobTagsAnswer.IsEmpty)
+                    {
+                        sendData[key] = jobTagsAnswer.Input;
+                        PrintPromptResult(label, $"\"{jobTagsAnswer.Input}\"");
+                    }
+                    else
+                    {
+                        PrintPromptResult(label, $"\"{requirements.Defaults.JobTags}\"", true);
+                    }
+                }
+                else { return false; }
+            }
+
+            // SkipTags
+            if (checkOptional && requirements.AskSkipTagsOnLaunch)
+            {
+                key = "skip_tags"; label = "Skip Tags";
+                if (sendData.ContainsKey(key))
+                {
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
+                }
+                else if (prompt.Ask(label,
+                                    defaultValue: requirements.Defaults.JobTags,
+                                    helpMessage: """
+                                    Enter the skip tags. Multiple values can be separated by commas(`,`).
+                                    This is same as the `--skip-tags` command-line parameter for `ansible-playbook`.
+                                    """,
+                                    out var skipTagsAnswer))
+                {
+                    if (!skipTagsAnswer.IsEmpty)
+                    {
+                        sendData[key] = skipTagsAnswer.Input;
+                        PrintPromptResult(label, $"\"{skipTagsAnswer.Input}\"");
+                    }
+                    else
+                    {
+                        PrintPromptResult(label, $"\"{requirements.Defaults.SkipTags}\"", true);
+                    }
+                }
+                else { return false; }
+            }
+
+            // ExtraVars
+            if (checkOptional && requirements.AskVariablesOnLaunch)
+            {
+                key = "extra_vars"; label = "Extra Variables";
+                if (sendData.ContainsKey(key))
+                {
+                    WriteHost(string.Format(skipFormat, label, sendData[key]), dontshow: true);
+                }
+                else if (prompt.Ask(label,
+                                    defaultValue: requirements.Defaults.ExtraVars,
+                                    helpMessage: """
+                                    Enter the extra variables provided key/value pairs using either YAML or JSON, to be passed to the playbook.
+                                    This is same as the `-e` or `--extra-vars` command-line parameter for `ansible-playbook`.
+                                    """,
+                                    out var extraVarsAnswer))
+                {
+                    if (!extraVarsAnswer.IsEmpty)
+                    {
+                        sendData[key] = extraVarsAnswer.Input;
+                        PrintPromptResult(label, extraVarsAnswer.Input);
+                    }
+                    else
+                    {
+                        PrintPromptResult(label, requirements.Defaults.ExtraVars, true);
+                    }
+                }
+                else { return false; }
+            }
+
+            // FIXME: implement Survey
+
+            return true;
+        }
+
         protected WorkflowJob.LaunchResult? Launch(ulong id)
         {
             var requirements = GetResource<WorkflowJobTemplateLaunchRequirements>($"{WorkflowJobTemplate.PATH}{id}/launch/");
@@ -241,6 +499,11 @@ namespace AWX.Cmdlets
                 return null;
             }
             var sendData = CreateSendData();
+            if (!TryAskOnLaunch(requirements, sendData, checkOptional: Interactive))
+            {
+                WriteWarning("Launch canceled.");
+                return null;
+            }
             var apiResult = CreateResource<WorkflowJob.LaunchResult>($"{WorkflowJobTemplate.PATH}{id}/launch/", sendData);
             var launchResult = apiResult.Contents;
             WriteVerbose($"Launch WorkflowJobTemplate:{id} => Job:[{launchResult.Id}]");


### PR DESCRIPTION
https://github.com/teramako/AWX.psm/pull/29 continued.

Add `-Interactive` paramater to  `Invoke-WorkflowJobTempalte` and `Start-WorkflowJobTemplate` cmdlets for inputing various parameter interactivly.

## ToDo
- Write document: Filed to #27 .