### PR TITLE
Add `UserId` and `UserName` properties in ApiConfig

### DIFF
--- a/src/ApiConfig.cs
+++ b/src/ApiConfig.cs
@@ -1,6 +1,7 @@
 using System.Management.Automation;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using AWX.Resources;
 
 namespace AWX
 {
@@ -138,5 +139,42 @@ namespace AWX
         }
         const string ENV_CONFIG = "ANSIBLE_API_CONFIG";
         const string DEFULT_CONFIG_NAME = ".ansible_api_config.json";
+
+        private User? _user = null;
+        private ulong? _userId = null;
+        private string? _userName = null;
+        internal User LoadUser(bool save = false, bool force = false)
+        {
+            if (force || _user == null)
+            {
+                var task = Resources.User.GetMe();
+                task.Wait();
+                _user = task.Result;
+            }
+            _userId = _user.Id;
+            _userName = _user.Username;
+            if (save && File != null)
+                Save();
+
+            return _user;
+        }
+        public ulong? UserId {
+            get
+            {
+                if (_userId == null)
+                    LoadUser(save: true);
+                return _userId;
+            }
+            init { _userId = value; }
+        }
+        public string? UserName {
+            get
+            {
+                if (string.IsNullOrEmpty(_userName))
+                    LoadUser(save: true);
+                return _userName;
+            }
+            init { _userName = value; }
+        }
     }
 }

--- a/src/ApiConfig.cs
+++ b/src/ApiConfig.cs
@@ -73,7 +73,7 @@ namespace AWX
             }
             LastSaved = DateTime.UtcNow;
             using var fs = fileInfo.OpenWrite();
-            JsonSerializer.Serialize(fs, this);
+            JsonSerializer.Serialize(fs, this, Json.DeserializeOptions);
         }
         public static ApiConfig Load(ApiConfig config)
         {
@@ -94,7 +94,7 @@ namespace AWX
                 return Load(new ApiConfig());
             }
             using var fs = fileInfo.OpenRead();
-            var config = JsonSerializer.Deserialize<ApiConfig>(fs)
+            var config = JsonSerializer.Deserialize<ApiConfig>(fs, Json.DeserializeOptions)
                 ?? throw new Exception($"Could not load config.");
             config.File = fileInfo;
             return Load(config);

--- a/src/Cmdlets/ApiConfigCommand.cs
+++ b/src/Cmdlets/ApiConfigCommand.cs
@@ -1,4 +1,3 @@
-using AWX.Resources;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Host;
@@ -86,9 +85,7 @@ namespace AWX.Cmdlets
             try
             {
                 Host.UI.WriteLine($"Try to retrieve the user information from: {config.Origin}");
-                var task = User.GetMe();
-                task.Wait();
-                var me = task.Result;
+                var me = config.LoadUser(save: false);
                 Host.UI.WriteLine($"Success: {me.Username}({me.Email})");
             }
             catch (Exception ex)


### PR DESCRIPTION
For showing `UserId` and `UserName` with `Get-ApiConfig` and load/save the properties to config file.

Add properties:
- `UserId`
- `UserName`

Implement method:
- `LoadUser()`: Get user information from `/api/v2/me/`, and save to file (optional)