### PR TITLE
Change output type of Registration cmdlets  to `void` from `bool`

### DIFF
--- a/docs/en-US/cmdlets/Register-Credential.md
+++ b/docs/en-US/cmdlets/Register-Credential.md
@@ -113,8 +113,7 @@ Credential ID.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Register-Group.md
+++ b/docs/en-US/cmdlets/Register-Group.md
@@ -108,8 +108,7 @@ Group Id to be a child.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Register-Host.md
+++ b/docs/en-US/cmdlets/Register-Host.md
@@ -108,8 +108,7 @@ Host Id.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Register-Label.md
+++ b/docs/en-US/cmdlets/Register-Label.md
@@ -115,8 +115,7 @@ Label ID.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Register-User.md
+++ b/docs/en-US/cmdlets/Register-User.md
@@ -111,8 +111,7 @@ User ID.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Unregister-Credential.md
+++ b/docs/en-US/cmdlets/Unregister-Credential.md
@@ -113,8 +113,7 @@ Credential ID.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Unregister-Group.md
+++ b/docs/en-US/cmdlets/Unregister-Group.md
@@ -108,8 +108,7 @@ Group Id.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Unregister-Host.md
+++ b/docs/en-US/cmdlets/Unregister-Host.md
@@ -108,8 +108,7 @@ Host Id.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Unregister-Label.md
+++ b/docs/en-US/cmdlets/Unregister-Label.md
@@ -115,8 +115,7 @@ Label ID.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/docs/en-US/cmdlets/Unregister-User.md
+++ b/docs/en-US/cmdlets/Unregister-User.md
@@ -106,8 +106,7 @@ User ID.
 
 ## OUTPUTS
 
-### System.Boolean
-Success or Failure
+### None
 
 ## NOTES
 

--- a/src/Cmdlets/CredentialCommand.cs
+++ b/src/Cmdlets/CredentialCommand.cs
@@ -157,7 +157,7 @@ namespace AWX.Cmdlets
     }
 
     [Cmdlet(VerbsLifecycle.Register, "Credential", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class RegisterCredentialCommand : RegistrationCommandBase<Credential>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -184,11 +184,11 @@ namespace AWX.Cmdlets
                 ResourceType.WorkflowJobTemplateNode => $"{WorkflowJobTemplateNode.PATH}{To.Id}/credentials/",
                 _ => throw new ArgumentException($"Invalid resource type: {To.Type}")
             };
-            WriteObject(Register(path, Id, To));
+            Register(path, Id, To);
         }
     }
     [Cmdlet(VerbsLifecycle.Unregister, "Credential", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class UnregisterCredentialCommand : RegistrationCommandBase<Credential>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -215,7 +215,7 @@ namespace AWX.Cmdlets
                 ResourceType.WorkflowJobTemplateNode => $"{WorkflowJobTemplateNode.PATH}{From.Id}/credentials/",
                 _ => throw new ArgumentException($"Invalid resource type: {From.Type}")
             };
-            WriteObject(Unregister(path, Id, From));
+            Unregister(path, Id, From);
         }
     }
 

--- a/src/Cmdlets/GroupCommand.cs
+++ b/src/Cmdlets/GroupCommand.cs
@@ -157,7 +157,7 @@ namespace AWX.Cmdlets
     }
 
     [Cmdlet(VerbsLifecycle.Register, "Group", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class RegisterGroupCommand : RegistrationCommandBase<Group>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -172,12 +172,12 @@ namespace AWX.Cmdlets
         {
             var parentGroup = new Resource(ResourceType.Group, To);
             var path = $"{Group.PATH}{parentGroup.Id}/children/";
-            WriteObject(Register(path, Id, parentGroup));
+            Register(path, Id, parentGroup);
         }
     }
 
     [Cmdlet(VerbsLifecycle.Unregister, "Group", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class UnregisterGroupCommand : RegistrationCommandBase<Group>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -192,7 +192,7 @@ namespace AWX.Cmdlets
         {
             var parentGroup = new Resource(ResourceType.Group, From);
             var path = $"{Group.PATH}{parentGroup.Id}/children/";
-            WriteObject(Unregister(path, Id, parentGroup));
+            Unregister(path, Id, parentGroup);
         }
     }
 

--- a/src/Cmdlets/HostCommand.cs
+++ b/src/Cmdlets/HostCommand.cs
@@ -184,7 +184,7 @@ namespace AWX.Cmdlets
     }
 
     [Cmdlet(VerbsLifecycle.Register, "Host", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class RegisterHostCommand : RegistrationCommandBase<Host>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -199,12 +199,12 @@ namespace AWX.Cmdlets
         {
             var parentGroup = new Resource(ResourceType.Group, To);
             var path = $"{Group.PATH}{parentGroup.Id}/hosts/";
-            WriteObject(Register(path, Id, parentGroup));
+            Register(path, Id, parentGroup);
         }
     }
 
     [Cmdlet(VerbsLifecycle.Unregister, "Host", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class UnregisterHostCommand : RegistrationCommandBase<Host>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -219,7 +219,7 @@ namespace AWX.Cmdlets
         {
             var parentGroup = new Resource(ResourceType.Group, From);
             var path = $"{Group.PATH}{parentGroup.Id}/hosts/";
-            WriteObject(Unregister(path, Id, parentGroup));
+            Unregister(path, Id, parentGroup);
         }
     }
 

--- a/src/Cmdlets/LabelCommand.cs
+++ b/src/Cmdlets/LabelCommand.cs
@@ -95,7 +95,7 @@ namespace AWX.Cmdlets
     }
 
     [Cmdlet(VerbsLifecycle.Register, "Label", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class RegisterLabelCommand : RegistrationCommandBase<Label>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -123,12 +123,12 @@ namespace AWX.Cmdlets
                 ResourceType.WorkflowJobTemplateNode => $"{WorkflowJobTemplateNode.PATH}{To.Id}/labels/",
                 _ => throw new ArgumentException($"Invalid resource type: {To.Type}")
             };
-            WriteObject(Register(path, Id, To));
+            Register(path, Id, To);
         }
     }
 
     [Cmdlet(VerbsLifecycle.Unregister, "Label", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class UnregisterLabelCommand : RegistrationCommandBase<Label>
     {
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
@@ -156,7 +156,7 @@ namespace AWX.Cmdlets
                 ResourceType.WorkflowJobTemplateNode => $"{WorkflowJobTemplateNode.PATH}{From.Id}/labels/",
                 _ => throw new ArgumentException($"Invalid resource type: {From.Type}")
             };
-            WriteObject(Unregister(path, Id, From));
+            Unregister(path, Id, From);
         }
     }
 

--- a/src/Cmdlets/UserCommand.cs
+++ b/src/Cmdlets/UserCommand.cs
@@ -327,7 +327,7 @@ namespace AWX.Cmdlets
     }
 
     [Cmdlet(VerbsLifecycle.Register, "User", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class RegisterUserCommand : RegistrationCommandBase<User>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -351,12 +351,12 @@ namespace AWX.Cmdlets
                 ResourceType.Role => $"{Role.PATH}{To.Id}/users/",
                 _ => throw new ArgumentException($"Invalid resource type: {To.Type}")
             };
-            WriteObject(Register(path, Id, To));
+            Register(path, Id, To);
         }
     }
 
     [Cmdlet(VerbsLifecycle.Unregister, "User", SupportsShouldProcess = true)]
-    [OutputType(typeof(bool))]
+    [OutputType(typeof(void))]
     public class UnregisterUserCommand : RegistrationCommandBase<User>
     {
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -380,7 +380,7 @@ namespace AWX.Cmdlets
                 ResourceType.Role => $"{Role.PATH}{From.Id}/users/",
                 _ => throw new ArgumentException($"Invalid resource type: {From.Type}")
             };
-            WriteObject(Unregister(path, Id, From));
+            Unregister(path, Id, From);
         }
     }
 


### PR DESCRIPTION
It would be more convenient to output nothing unless an exception occurs.

fix for https://github.com/teramako/AWX.psm/pull/70