### PR TITLE
Fix Find-CredentialInputSource

### DIFF
--- a/docs/en-US/cmdlets/Find-CredentialInputSource.md
+++ b/docs/en-US/cmdlets/Find-CredentialInputSource.md
@@ -12,15 +12,8 @@ Retrieve CredentialsInputSources.
 
 ## SYNTAX
 
-### All (Default)
 ```
-Find-CredentialInputSource [-OrderBy <String[]>] [-Search <String[]>] [-Filter <NameValueCollection>]
- [-Count <UInt16>] [-Page <UInt32>] [-All] [<CommonParameters>]
-```
-
-### AssociatedWith
-```
-Find-CredentialInputSource [-Type <ResourceType>] -Id <UInt64> [-OrderBy <String[]>] [-Search <String[]>]
+Find-CredentialInputSource [[-Credential] <UInt64>] [-OrderBy <String[]>] [-Search <String[]>]
  [-Filter <NameValueCollection>] [-Count <UInt16>] [-Page <UInt32>] [-All] [<CommonParameters>]
 ```
 
@@ -40,18 +33,10 @@ PS C:\> Find-CredentialInputSource
 
 ### Example 2
 ```powershell
-PS C:\> Find-CredentialInputSource -Type Credential -Id 10
+PS C:\> Find-CredentialInputSource -Credential 10
 ```
 
 Retrieve CredentialInputSources associated with the Credential of ID 10.
-
-`Id` and `Type` parameters can also be given from the pipeline, likes following:
-
-    Get-Credential -Id 10 | Find-CredentialInputSource
-
-and also can omit `-Type` parameter:
-
-    Find-CredentialInputSource -Id 10
 
 ## PARAMETERS
 
@@ -85,6 +70,26 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Credential
+Credential ID or it's object.
+Retrieve CredenialInputSource which the Credential associated with.
+
+> [!TIP]  
+> Can specify `IResource` object.  
+> For example: `-Credential (Get-Credential-Id 3)`, `-Credential $creds[1]`
+
+```yaml
+Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
 ### -Filter
 Filtering various fields.
 
@@ -104,21 +109,6 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-Datebase ID of the target Credential resource.
-
-```yaml
-Type: UInt64
-Parameter Sets: AssociatedWith
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -175,37 +165,14 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Type
-Resource type name of the target.
-Use in conjection with the `-Id` parameter.
-
-```yaml
-Type: ResourceType
-Parameter Sets: AssociatedWith
-Aliases:
-Accepted values: Credential
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### AWX.Resources.ResourceType
-Input by `Type` property in the pipeline object.
-
-Acceptable values: `Credential` (only)
-
 ### System.UInt64
-Input by `Id` property in the pipeline object.
-
-Database ID for `Credential`
+Credential ID or it's object.
+See: `-Credential` parameter.
 
 ## OUTPUTS
 

--- a/src/Cmdlets/CredentialInputSourceCommand.cs
+++ b/src/Cmdlets/CredentialInputSourceCommand.cs
@@ -19,15 +19,13 @@ namespace AWX.Cmdlets
         }
     }
 
-    [Cmdlet(VerbsCommon.Find, "CredentialInputSource", DefaultParameterSetName = "All")]
+    [Cmdlet(VerbsCommon.Find, "CredentialInputSource")]
     [OutputType(typeof(CredentialInputSource))]
     public class FindCredentialInputSourceCommand : FindCommandBase
     {
-        [Parameter(ParameterSetName = "AssociatedWith", ValueFromPipelineByPropertyName = true)]
-        [ValidateSet(nameof(ResourceType.Credential))]
-        public ResourceType Type { get; set; }
-        [Parameter(Mandatory = true, ParameterSetName = "AssociatedWith", ValueFromPipelineByPropertyName = true)]
-        public ulong Id { get; set; }
+        [Parameter(ValueFromPipeline = true, Position = 0)]
+        [ResourceIdTransformation(AcceptableTypes = [ResourceType.Credential])]
+        public ulong Credential { get; set; }
 
         [Parameter()]
         public override string[] OrderBy { get; set; } = ["id"];
@@ -38,7 +36,7 @@ namespace AWX.Cmdlets
         }
         protected override void ProcessRecord()
         {
-            var path = Id > 0 ? $"{Credential.PATH}{Id}/input_sources/" : CredentialInputSource.PATH;
+            var path = Credential > 0 ? $"{Resources.Credential.PATH}{Credential}/input_sources/" : CredentialInputSource.PATH;
             Find<CredentialInputSource>(path);
         }
     }


### PR DESCRIPTION
For `Find-CredentialInputSource`

- Obsolete `-Type` and `-Id` parameters
- replace with `-User` perameter