### PR TITLE
:+1: Replace `-Type` and `-Id` parameter to `-Project` for Find-ProjectUpdateJob

### DIFF
--- a/docs/en-US/cmdlets/Find-ProjectUpdateJob.md
+++ b/docs/en-US/cmdlets/Find-ProjectUpdateJob.md
@@ -12,17 +12,10 @@ Retrieve jobs for ProjectUpdate.
 
 ## SYNTAX
 
-### All (Default)
 ```
-Find-ProjectUpdateJob [[-Name] <String[]>] [-Status <String[]>] [-OrderBy <String[]>] [-Search <String[]>]
- [-Filter <NameValueCollection>] [-Count <UInt16>] [-Page <UInt32>] [-All] [<CommonParameters>]
-```
-
-### AssociatedWith
-```
-Find-ProjectUpdateJob -Type <ResourceType> -Id <UInt64> [[-Name] <String[]>] [-Status <String[]>]
- [-OrderBy <String[]>] [-Search <String[]>] [-Filter <NameValueCollection>] [-Count <UInt16>] [-Page <UInt32>]
- [-All] [<CommonParameters>]
+Find-ProjectUpdateJob [[-Project] <UInt64>] [-Name <String[]>] [-Status <String[]>] [-OrderBy <String[]>]
+ [-Search <String[]>] [-Filter <NameValueCollection>] [-Count <UInt16>] [-Page <UInt32>] [-All]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -43,16 +36,10 @@ Retreive successfully completed ProjectUpdate jobs.
 
 ### Example 2
 ```powershell
-PS C:\> Find-ProjectUpdateJob -Type Project -Id 1
+PS C:\> Find-ProjectUpdateJob -Project 1
 ```
 
 Retrieve ProjectUpdate jobs associated with the Project of ID 1
-
-`Id` and `Type` parameters can also be given from the pipeline, likes following:  
-    Get-Project -Id 1 | Find-ProjectUpdateJob
-
-and also can omit `-Type` parameter:  
-    Find-ProjectUpdateJob -Id 1
 
 ## PARAMETERS
 
@@ -108,22 +95,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Id
-Datebase ID of the target resource.
-Use in conjection with the `-Type` parameter.
-
-```yaml
-Type: UInt64
-Parameter Sets: AssociatedWith
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### -Name
 Filter by ProjectUpdate job name.
 The names must be an exact match. (case-sensitive)
@@ -136,7 +107,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -176,6 +147,26 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Project
+Project ID or it's object.
+Filter to ProjectUpdateJobs of the Project for the specified ID.
+
+> [!TIP]  
+> Can specify `IResource` object.  
+> For example: `-Project (Get-Project -Id 3)`, `-Project $project`
+
+```yaml
+Type: UInt64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
 ### -Search
 Search words. (case-insensitive)
 
@@ -211,37 +202,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Type
-Resource type name of the target.
-Use in conjection with the `-Id` parameter.
-
-```yaml
-Type: ResourceType
-Parameter Sets: AssociatedWith
-Aliases:
-Accepted values: Project
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-### AWX.Resources.ResourceType
-Input by `Type` property in the pipeline object.
-
-Acceptable values: `Project` (only)
-
-### System.UInt64
-Input by `Id` property in the pipeline object.
-
-Database ID for `Project`
+### AWX.Resources.IResource
+Project ID or it's object.
 
 ## OUTPUTS
 

--- a/src/Cmdlets/ProjectUpdateCommand.cs
+++ b/src/Cmdlets/ProjectUpdateCommand.cs
@@ -15,17 +15,15 @@ namespace AWX.Cmdlets
         }
     }
 
-    [Cmdlet(VerbsCommon.Find, "ProjectUpdateJob", DefaultParameterSetName = "All")]
+    [Cmdlet(VerbsCommon.Find, "ProjectUpdateJob")]
     [OutputType(typeof(ProjectUpdateJob))]
     public class FindProjectUpdateJobCommand : FindCommandBase
     {
-        [Parameter(Mandatory = true, ParameterSetName = "AssociatedWith", ValueFromPipelineByPropertyName = true)]
-        [ValidateSet(nameof(ResourceType.Project))]
-        public ResourceType Type { get; set; }
-        [Parameter(Mandatory = true, ParameterSetName = "AssociatedWith", ValueFromPipelineByPropertyName = true)]
-        public ulong Id { get; set; }
+        [Parameter(ValueFromPipeline = true, Position = 0)]
+        [ResourceIdTransformation(AcceptableTypes = [ResourceType.Project])]
+        public ulong Project { get; set; }
 
-        [Parameter(Position = 0)]
+        [Parameter()]
         public string[]? Name { get; set; }
 
         [Parameter()]
@@ -50,11 +48,7 @@ namespace AWX.Cmdlets
         }
         protected override void EndProcessing()
         {
-            var path = Type switch
-            {
-                ResourceType.Project => $"{Project.PATH}{Id}/project_updates/",
-                _ => ProjectUpdateJob.PATH
-            };
+            var path = Project > 0 ? $"{Resources.Project.PATH}{Project}/project_updates/" : ProjectUpdateJob.PATH;
             Find<ProjectUpdateJob>(path);
         }
     }


### PR DESCRIPTION
**BREAKING CHANGE**

For `Find-ProjectUpdateJob`
- Obsolete `-Type` and `-Id` parameters
- replace with `-Project` perameter