### PR TITLE
:+1: Replace `-Type` and `-Id` parameter to `-SystemJobTemplate` for Find-SystemJob

### DIFF
--- a/docs/en-US/cmdlets/Find-SystemJob.md
+++ b/docs/en-US/cmdlets/Find-SystemJob.md
@@ -12,17 +12,9 @@ Retrieve jobs for SystemJobTemplate.
 
 ## SYNTAX
 
-### All (Default)
 ```
-Find-SystemJob [-Status <String[]>] [-OrderBy <String[]>] [-Search <String[]>] [-Filter <NameValueCollection>]
- [-Count <UInt16>] [-Page <UInt32>] [-All] [<CommonParameters>]
-```
-
-### AssociatedWith
-```
-Find-SystemJob [-Type <ResourceType>] -Id <UInt64> [-Status <String[]>] [-OrderBy <String[]>]
- [-Search <String[]>] [-Filter <NameValueCollection>] [-Count <UInt16>] [-Page <UInt32>] [-All]
- [<CommonParameters>]
+Find-SystemJob [[-SystemJobTemplate] <UInt64>] [-Status <String[]>] [-OrderBy <String[]>] [-Search <String[]>]
+ [-Filter <NameValueCollection>] [-Count <UInt16>] [-Page <UInt32>] [-All] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -106,22 +98,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Id
-Datebase ID of the target resource.
-Use in conjection with the `-Type` parameter.
-
-```yaml
-Type: UInt64
-Parameter Sets: AssociatedWith
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### -OrderBy
 Retrieve list in the specified orders.
 Use `!` prefix to sort in reverse.
@@ -191,20 +167,19 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Type
-Resource type name of the target.
-Use in conjection with the `-Id` parameter.
+### -SystemJobTemplate
+SystemJobTemplate ID or it's object.
+Retrieve jobs which the SystemJobTemplate associated with.
 
 ```yaml
-Type: ResourceType
-Parameter Sets: AssociatedWith
+Type: UInt64
+Parameter Sets: (All)
 Aliases:
-Accepted values: SystemJobTemplate
 
 Required: False
-Position: Named
+Position: 0
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
@@ -219,9 +194,7 @@ Input by `Type` property in the pipeline object.
 Acceptable values: `SystemJobTemplate` (only)
 
 ### System.UInt64
-Input by `Id` property in the pipeline object.
-
-Database ID for `SystemJobTemplate`
+SystemJobTemplate ID or it's object.
 
 ## OUTPUTS
 

--- a/src/Cmdlets/SystemJobCommand.cs
+++ b/src/Cmdlets/SystemJobCommand.cs
@@ -15,15 +15,13 @@ namespace AWX.Cmdlets
         }
     }
 
-    [Cmdlet(VerbsCommon.Find, "SystemJob", DefaultParameterSetName = "All")]
+    [Cmdlet(VerbsCommon.Find, "SystemJob")]
     [OutputType(typeof(SystemJob))]
     public class FindSystemJobCommand : FindCommandBase
     {
-        [Parameter(ParameterSetName = "AssociatedWith", ValueFromPipelineByPropertyName = true)]
-        [ValidateSet(nameof(ResourceType.SystemJobTemplate))]
-        public ResourceType Type { get; set; }
-        [Parameter(Mandatory = true, ParameterSetName = "AssociatedWith", ValueFromPipelineByPropertyName = true)]
-        public ulong Id { get; set; }
+        [Parameter(ValueFromPipeline = true, Position = 0)]
+        [ResourceIdTransformation(AcceptableTypes = [ResourceType.SystemJobTemplate])]
+        public ulong SystemJobTemplate { get; set; }
 
         [Parameter()]
         [ValidateSet(typeof(EnumValidateSetGenerator<JobStatus>))]
@@ -43,7 +41,7 @@ namespace AWX.Cmdlets
         }
         protected override void ProcessRecord()
         {
-            var path = Id > 0 ? $"{SystemJobTemplate.PATH}{Id}/jobs/" : SystemJob.PATH;
+            var path = SystemJobTemplate > 0 ? $"{Resources.SystemJobTemplate.PATH}{SystemJobTemplate}/jobs/" : SystemJob.PATH;
             Find<SystemJob>(path);
         }
     }


### PR DESCRIPTION
**BREAKING CHANGE**

For `Find-SystemJob`
- Obsolete `-Type` and `-Id` parameters
- replace with `-SystemJobTemplate` perameter